### PR TITLE
Fix NoClassDefFoundError error message

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -235,6 +235,7 @@ project('pxf-tkh') {
     dependencies {
         compile(project(':pxf-api'))
 
+        compile "org.apache.httpcomponents:httpcore-nio:4.4.11"
         compile "org.apache.httpcomponents:httpasyncclient:4.1.4"
     }
 }


### PR DESCRIPTION
A `build.gradle` file misses `httpcore-nio` dependency from `org.apache.httpcomponents` - otherwise TKH fails with NoClassDefFoundError during inserting data to target clickhouse database.