### PR TITLE
Remove the error-causing check

### DIFF
--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/writercallable/SimpleWriterCallable.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/writercallable/SimpleWriterCallable.java
@@ -64,9 +64,7 @@ class SimpleWriterCallable implements WriterCallable {
         JdbcResolver.decodeOneRowToPreparedStatement(row, statement);
 
         try {
-            if (statement.executeUpdate() != 1) {
-                throw new SQLException("The number of rows affected by INSERT query is not equal to the number of rows provided");
-            }
+            statement.executeUpdate();
         } catch (SQLException e) {
             return e;
         } finally {


### PR DESCRIPTION
The hive jdbc driver not fully implemented `executeUpdate()` function. The result of this function is a value that determines how many rows have been modified, but it always returns `0` ([link to code](https://github.com/apache/hive/blob/b46b02524cbcef92eca346ffa5a9e9bba83776e3/jdbc/src/java/org/apache/hive/jdbc/HiveStatement.java#L510)).  This causes an error even if the `INSERT` is successful. (The problem in hive is fixed in later versions that havent been released yet. [link to issue](https://issues.apache.org/jira/browse/HIVE-12432))

To fix this problem, it was decided to remove the error-causing check. This check is not necessary. `executeUpdate()` throws an exception in case of an error and doesn't return `0`; it is also contrary to the SQL semantics for an INSERT statement to return anything other than `1` when no error happens. That is, checking the return value is redundant. 