### PR TITLE
Remove the error-causing check [Backport]

### DIFF
--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/writercallable/SimpleWriterCallable.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/writercallable/SimpleWriterCallable.java
@@ -64,9 +64,7 @@ class SimpleWriterCallable implements WriterCallable {
         JdbcResolver.decodeOneRowToPreparedStatement(row, statement);
 
         try {
-            if (statement.executeUpdate() != 1) {
-                throw new SQLException("The number of rows affected by INSERT query is not equal to the number of rows provided");
-            }
+            statement.executeUpdate();
         } catch (SQLException e) {
             return e;
         } finally {


### PR DESCRIPTION
This check is not necessary. executeUpdate() throws an exception in case of an error and doesn't return 0; it is also contrary to the SQL semantics for an INSERT statement to return anything other than 1 when no error happens. That is, checking the return value is redundant. Also, the implementation of the function in hive jdbc driver always returns 0. Because of this, even in the case of a successful INSERT, an error was thrown.