### PR TITLE
AIS-146: Bump version for hive-jdbc

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -142,7 +142,7 @@ configure(javaProjects) {
             }
             // 1.2.2 breaks on CDH-5.x
             // We use custom hive-jdbc driver from Arenadata
-            dependencySet(group:"io.arenadata.hive", version:"2.3.8-arenadata-pxf-1") {
+            dependencySet(group:"io.arenadata.hive", version:"2.3.8-arenadata-pxf-3") {
                 entry("hive-jdbc")
             }
             dependencySet(group:"org.apache.hive.shims", version:"${hiveVersion}") {


### PR DESCRIPTION
The previous version of the hive-jdbc depends on the vulnerability version of log4j library.