### PR TITLE
AIS-149: Fix wrapDateWithTime() method for DBs

### DIFF
--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/utils/DbProduct.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/utils/DbProduct.java
@@ -34,7 +34,7 @@ public enum DbProduct {
 
         @Override
         public String wrapDateWithTime(Object val) {
-            return wrapDate(val);
+            return wrapTimestamp(val);
         }
 
         @Override
@@ -51,7 +51,7 @@ public enum DbProduct {
 
         @Override
         public String wrapDateWithTime(Object val) {
-            return wrapDate(val);
+            return wrapTimestamp(val);
         }
     },
 
@@ -90,7 +90,7 @@ public enum DbProduct {
 
         @Override
         public String wrapDateWithTime(Object val) {
-            return wrapDate(val);
+            return wrapTimestamp(val);
         }
     },
 
@@ -102,7 +102,7 @@ public enum DbProduct {
 
         @Override
         public String wrapDateWithTime(Object val) {
-            return wrapDate(val);
+            return wrapTimestamp(val);
         }
 
         @Override
@@ -117,7 +117,7 @@ public enum DbProduct {
 
         @Override
         public String wrapDateWithTime(Object val) {
-            return wrapDate(val);
+            return wrapTimestamp(val);
         }
 
         @Override


### PR DESCRIPTION
If `CONVERT_ORACLE_DATE=true` the `timestamp` type has to be converted to `date` type only for Oracle. 
For other DBs the `timestamp` has to be converted to the `timestamp` even the parameter `CONVERT_ORACLE_DATE=true`.

I made a mistake in my previous commit and returned wrapDate(val) instead wrapTimestamp(val) for other DBs when `CONVERT_ORACLE_DATE=true`. It is not correct. 

This PR has to resolve the issue.

