### PR TITLE
ADBDEV-2753: Incorrect work bool data type in query to pxf foreign table 

### DIFF
--- a/automation/tincrepo/main/pxf/features/columnprojection/checkColumnProjection/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/columnprojection/checkColumnProjection/expected/query01.ans
@@ -56,9 +56,40 @@ SELECT colprojvalue FROM test_column_projection ORDER BY t0;
  t0|colprojvalue
 (10 rows)
 
--- Column Projection is not supported for boolean?
--- SELECT t0, colprojvalue FROM test_column_projection WHERE b2 ORDER BY t0;
---
+SELECT t0, colprojvalue FROM test_column_projection WHERE b2 ORDER BY t0;
+ t0 |    colprojvalue
+----+--------------------
+ A  | t0|b2|colprojvalue
+ C  | t0|b2|colprojvalue
+ E  | t0|b2|colprojvalue
+ G  | t0|b2|colprojvalue
+ I  | t0|b2|colprojvalue
+(5 rows)
+
+SELECT t0, a1, colprojvalue FROM test_column_projection WHERE a1 < 5 AND b2 = false ORDER BY t0;
+ t0 | a1 |     colprojvalue
+----+----+-----------------------
+ B  |  1 | t0|a1|b2|colprojvalue
+ D  |  3 | t0|a1|b2|colprojvalue
+(2 rows)
+
+SELECT sqrt(a1), colprojvalue FROM test_column_projection WHERE a1 < 5 AND b2 = false ORDER BY t0;
+       sqrt       |     colprojvalue
+------------------+-----------------------
+                1 | t0|a1|b2|colprojvalue
+ 1.73205080756888 | t0|a1|b2|colprojvalue
+(2 rows)
+
+SELECT sqrt(a1), colprojvalue FROM test_column_projection WHERE b2 = false ORDER BY t0;
+       sqrt       |     colprojvalue
+------------------+-----------------------
+                1 | t0|a1|b2|colprojvalue
+ 1.73205080756888 | t0|a1|b2|colprojvalue
+ 2.23606797749979 | t0|a1|b2|colprojvalue
+ 2.64575131106459 | t0|a1|b2|colprojvalue
+                3 | t0|a1|b2|colprojvalue
+(5 rows)
+
 SELECT t0, colprojvalue FROM test_column_projection WHERE a1 < 5 ORDER BY t0;
  t0 |    colprojvalue
 ----+--------------------
@@ -196,9 +227,40 @@ SELECT colprojvalue FROM test_column_projection ORDER BY t0;
  t0|colprojvalue
 (10 rows)
 
--- Column Projection is not supported for boolean?
--- SELECT t0, colprojvalue FROM test_column_projection WHERE b2 ORDER BY t0;
---
+SELECT t0, colprojvalue FROM test_column_projection WHERE b2 ORDER BY t0;
+ t0 |    colprojvalue
+----+--------------------
+ A  | t0|b2|colprojvalue
+ C  | t0|b2|colprojvalue
+ E  | t0|b2|colprojvalue
+ G  | t0|b2|colprojvalue
+ I  | t0|b2|colprojvalue
+(5 rows)
+
+SELECT t0, a1, colprojvalue FROM test_column_projection WHERE a1 < 5 AND b2 = false ORDER BY t0;
+ t0 | a1 |     colprojvalue
+----+----+-----------------------
+ B  |  1 | t0|a1|b2|colprojvalue
+ D  |  3 | t0|a1|b2|colprojvalue
+(2 rows)
+
+SELECT sqrt(a1), colprojvalue FROM test_column_projection WHERE a1 < 5 AND b2 = false ORDER BY t0;
+       sqrt       |     colprojvalue
+------------------+-----------------------
+                1 | t0|a1|b2|colprojvalue
+ 1.73205080756888 | t0|a1|b2|colprojvalue
+(2 rows)
+
+SELECT sqrt(a1), colprojvalue FROM test_column_projection WHERE b2 = false ORDER BY t0;
+       sqrt       |     colprojvalue
+------------------+-----------------------
+                1 | t0|a1|b2|colprojvalue
+ 1.73205080756888 | t0|a1|b2|colprojvalue
+ 2.23606797749979 | t0|a1|b2|colprojvalue
+ 2.64575131106459 | t0|a1|b2|colprojvalue
+                3 | t0|a1|b2|colprojvalue
+(5 rows)
+
 SELECT t0, colprojvalue FROM test_column_projection WHERE a1 < 5 ORDER BY t0;
  t0 |    colprojvalue
 ----+--------------------

--- a/automation/tincrepo/main/pxf/features/columnprojection/checkColumnProjection/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/columnprojection/checkColumnProjection/sql/query01.sql
@@ -13,9 +13,14 @@ SELECT t0, colprojvalue FROM test_column_projection ORDER BY t0;
 
 SELECT colprojvalue FROM test_column_projection ORDER BY t0;
 
--- Column Projection is not supported for boolean?
--- SELECT t0, colprojvalue FROM test_column_projection WHERE b2 ORDER BY t0;
---
+SELECT t0, colprojvalue FROM test_column_projection WHERE b2 ORDER BY t0;
+
+SELECT t0, a1, colprojvalue FROM test_column_projection WHERE a1 < 5 AND b2 = false ORDER BY t0;
+
+SELECT sqrt(a1), colprojvalue FROM test_column_projection WHERE a1 < 5 AND b2 = false ORDER BY t0;
+
+SELECT sqrt(a1), colprojvalue FROM test_column_projection WHERE b2 = false ORDER BY t0;
+
 SELECT t0, colprojvalue FROM test_column_projection WHERE a1 < 5 ORDER BY t0;
 
 SELECT t0, colprojvalue FROM test_column_projection WHERE a1 <= 5 ORDER BY t0;
@@ -41,9 +46,14 @@ SELECT t0, colprojvalue FROM test_column_projection ORDER BY t0;
 
 SELECT colprojvalue FROM test_column_projection ORDER BY t0;
 
--- Column Projection is not supported for boolean?
--- SELECT t0, colprojvalue FROM test_column_projection WHERE b2 ORDER BY t0;
---
+SELECT t0, colprojvalue FROM test_column_projection WHERE b2 ORDER BY t0;
+
+SELECT t0, a1, colprojvalue FROM test_column_projection WHERE a1 < 5 AND b2 = false ORDER BY t0;
+
+SELECT sqrt(a1), colprojvalue FROM test_column_projection WHERE a1 < 5 AND b2 = false ORDER BY t0;
+
+SELECT sqrt(a1), colprojvalue FROM test_column_projection WHERE b2 = false ORDER BY t0;
+
 SELECT t0, colprojvalue FROM test_column_projection WHERE a1 < 5 ORDER BY t0;
 
 SELECT t0, colprojvalue FROM test_column_projection WHERE a1 <= 5 ORDER BY t0;

--- a/automation/tincrepo/main/pxf/features/filterpushdown/checkFilterPushDown/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/filterpushdown/checkFilterPushDown/expected/query01.ans
@@ -41,6 +41,30 @@ SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
  J  |  9 | f  | a2c16s4dtrueo0l2
 (5 rows)
 
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+ t0 | a1 |          filtervalue
+----+----+-------------------------------
+ B  |  1 | a2c16s4dtrueo0l2a1c23s1d5o1l0
+ D  |  3 | a2c16s4dtrueo0l2a1c23s1d5o1l0
+(2 rows)
+
+SELECT sqrt(a1), filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+       sqrt       |          filtervalue
+------------------+-------------------------------
+                1 | a2c16s4dtrueo0l2a1c23s1d5o1l0
+ 1.73205080756888 | a2c16s4dtrueo0l2a1c23s1d5o1l0
+(2 rows)
+
+SELECT sqrt(a1), filtervalue FROM test_filter WHERE b2 = false ORDER BY t0;
+       sqrt       |   filtervalue
+------------------+------------------
+                1 | a2c16s4dtrueo0l2
+ 1.73205080756888 | a2c16s4dtrueo0l2
+ 2.23606797749979 | a2c16s4dtrueo0l2
+ 2.64575131106459 | a2c16s4dtrueo0l2
+                3 | a2c16s4dtrueo0l2
+(5 rows)
+
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
  t0 | a1 | b2 |                 filtervalue
 ----+----+----+---------------------------------------------
@@ -95,6 +119,30 @@ SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
  F  |  5 | f  | a2c16s4dtrueo0l2
  H  |  7 | f  | a2c16s4dtrueo0l2
  J  |  9 | f  | a2c16s4dtrueo0l2
+(5 rows)
+
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+ t0 | a1 |          filtervalue
+----+----+-------------------------------
+ B  |  1 | a1c23s1d5o1a2c16s4dtrueo0l2l0
+ D  |  3 | a1c23s1d5o1a2c16s4dtrueo0l2l0
+(2 rows)
+
+SELECT sqrt(a1), filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+       sqrt       |          filtervalue
+------------------+-------------------------------
+                1 | a1c23s1d5o1a2c16s4dtrueo0l2l0
+ 1.73205080756888 | a1c23s1d5o1a2c16s4dtrueo0l2l0
+(2 rows)
+
+SELECT sqrt(a1), filtervalue FROM test_filter WHERE b2 = false ORDER BY t0;
+       sqrt       |   filtervalue
+------------------+------------------
+                1 | a2c16s4dtrueo0l2
+ 1.73205080756888 | a2c16s4dtrueo0l2
+ 2.23606797749979 | a2c16s4dtrueo0l2
+ 2.64575131106459 | a2c16s4dtrueo0l2
+                3 | a2c16s4dtrueo0l2
 (5 rows)
 
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;

--- a/automation/tincrepo/main/pxf/features/filterpushdown/checkFilterPushDown/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/filterpushdown/checkFilterPushDown/sql/query01.sql
@@ -13,6 +13,12 @@ SELECT * FROM test_filter WHERE  t0 = 'B' OR (a1 >= 0 AND a1 <= 2) ORDER BY t0, 
 
 SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
 
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+
+SELECT sqrt(a1), filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+
+SELECT sqrt(a1), filtervalue FROM test_filter WHERE b2 = false ORDER BY t0;
+
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
 
 SELECT * FROM test_filter WHERE  b2 = false OR (a1 >= 0 AND a1 <= 2) ORDER BY t0, a1;
@@ -28,6 +34,12 @@ SELECT * FROM test_filter WHERE  t0 = 'B' AND (a1 = 1 OR a1 = 10) ORDER BY t0, a
 SELECT * FROM test_filter WHERE  t0 = 'B' OR (a1 >= 0 AND a1 <= 2) ORDER BY t0, a1;
 
 SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
+
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+
+SELECT sqrt(a1), filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+
+SELECT sqrt(a1), filtervalue FROM test_filter WHERE b2 = false ORDER BY t0;
 
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
 

--- a/external-table/src/pxffilters.c
+++ b/external-table/src/pxffilters.c
@@ -1427,6 +1427,12 @@ extractPxfAttributes(List *quals, bool *qualsAreSupported)
 					append_attr_from_var((Var *) expr->arg, attributes);
 				break;
 			}
+			case T_Var:
+			{
+				attributes        =
+					append_attr_from_var((Var*) node, attributes);
+				break;
+			}
 			default:
 			{
 				/*

--- a/external-table/src/pxfheaders.c
+++ b/external-table/src/pxfheaders.c
@@ -373,6 +373,7 @@ add_projection_desc_httpheader(CHURL_HEADERS headers,
 	TupleDesc		tupdesc;
 
 	initStringInfo(&formatter);
+	attrs_used = NULL;
 	number = 0;
 
 #if PG_VERSION_NUM >= 90400
@@ -407,9 +408,9 @@ add_projection_desc_httpheader(CHURL_HEADERS headers,
 			int attno = lfirst_int(lc1);
 			if (attno > InvalidAttrNumber)
 			{
-				add_projection_index_header(headers,
-											formatter, attno - 1, long_number);
-				number++;
+				attrs_used =
+					bms_add_member(attrs_used,
+									attno - FirstLowInvalidHeapAttributeNumber);
 			}
 		}
 
@@ -422,7 +423,6 @@ add_projection_desc_httpheader(CHURL_HEADERS headers,
 	}
 #endif
 
-	attrs_used = NULL;
 
 #if PG_VERSION_NUM >= 90400
 	for (i = 0; i < projInfo->pi_numSimpleVars; i++)

--- a/external-table/src/pxfheaders.c
+++ b/external-table/src/pxfheaders.c
@@ -363,7 +363,6 @@ add_projection_desc_httpheader(CHURL_HEADERS headers,
 	int			   i;
 	int			   dropped_count;
 	int			   number;
-	int			   numTargetList;
 #if PG_VERSION_NUM < 90400
 	int			   numSimpleVars;
 #endif
@@ -374,7 +373,7 @@ add_projection_desc_httpheader(CHURL_HEADERS headers,
 	TupleDesc		tupdesc;
 
 	initStringInfo(&formatter);
-	numTargetList = 0;
+	number = 0;
 
 #if PG_VERSION_NUM >= 90400
 	/*
@@ -410,7 +409,7 @@ add_projection_desc_httpheader(CHURL_HEADERS headers,
 			{
 				add_projection_index_header(headers,
 											formatter, attno - 1, long_number);
-				numTargetList++;
+				number++;
 			}
 		}
 
@@ -423,21 +422,7 @@ add_projection_desc_httpheader(CHURL_HEADERS headers,
 	}
 #endif
 
-	number = numTargetList +
-#if PG_VERSION_NUM >= 90400
-		projInfo->pi_numSimpleVars +
-#else
-		numSimpleVars +
-#endif
-		list_length(qualsAttributes);
-	if (number == 0)
-		return;
-
 	attrs_used = NULL;
-
-	/* Convert the number of projection columns to a string */
-	pg_ltoa(number, long_number);
-	churl_headers_append(headers, "X-GP-ATTRS-PROJ", long_number);
 
 #if PG_VERSION_NUM >= 90400
 	for (i = 0; i < projInfo->pi_numSimpleVars; i++)
@@ -481,7 +466,15 @@ add_projection_desc_httpheader(CHURL_HEADERS headers,
 			/* Shift the column index by the running dropped_count */
 			add_projection_index_header(headers, formatter,
 										i - 1 - dropped_count, long_number);
+			number++;
 		}
+	}
+
+	if (number != 0)
+	{
+		/* Convert the number of projection columns to a string */
+		pg_ltoa(number, long_number);
+		churl_headers_append(headers, "X-GP-ATTRS-PROJ", long_number);
 	}
 
 	list_free(qualsAttributes);

--- a/fdw/pxf_deparse.c
+++ b/fdw/pxf_deparse.c
@@ -73,5 +73,6 @@ classifyConditions(PlannerInfo *root,
 
 		/* for now, just assume that all WHERE clauses are OK on remote */
 		*remote_conds = lappend(*remote_conds, ri);
+		*local_conds = lappend(*local_conds, ri);
 	}
 }

--- a/regression/expected/FDW_FilterPushDownTest.out
+++ b/regression/expected/FDW_FilterPushDownTest.out
@@ -3,6 +3,29 @@
 -----------------------------------------------------
 -- Check that the filter is being pushed down. We create an external table
 -- that returns the filter being sent from the C-side
+CREATE SERVER loopback FOREIGN DATA WRAPPER jdbc_pxf_fdw OPTIONS (jdbc_driver 'org.postgresql.Driver', db_url 'jdbc:postgresql://localhost:5432/gpadmin');
+CREATE USER MAPPING FOR CURRENT_USER SERVER loopback;
+CREATE FOREIGN TABLE foreign_tb_test (id int,  v_text text, v_bool bool) SERVER loopback OPTIONS ( resource 'public.tb_test_t' );
+explain analyze select v_text from foreign_tb_test where v_text = '5' and  v_bool = false ;
+                                                             QUERY PLAN
+------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=50000.00..50000.00 rows=1000 width=32) (actual time=25.552..25.554 rows=1 loops=1)
+   ->  Foreign Scan on foreign_tb_test  (cost=50000.00..50000.00 rows=334 width=32) (actual time=0.369..0.371 rows=1 loops=1)
+         Filter: ((NOT v_bool) AND (v_text = '5'::text))
+ Planning time: 3.438 ms
+   (slice0)    Executor memory: 59K bytes.
+   (slice1)    Executor memory: 111K bytes avg x 3 workers, 138K bytes max (seg1).
+ Memory used:  128000kB
+ Optimizer: Postgres query optimizer
+ Execution time: 25.723 ms
+(9 rows)
+
+select v_text from foreign_tb_test where v_text = '5' and  v_bool = false ;
+ v_text 
+--------
+ 5
+(1 row)
+
 CREATE FOREIGN DATA WRAPPER pxf_filter_push_down_fdw
     HANDLER pxf_fdw_handler
     VALIDATOR pxf_fdw_validator

--- a/regression/expected/FDW_FilterPushDownTest.out
+++ b/regression/expected/FDW_FilterPushDownTest.out
@@ -3,29 +3,6 @@
 -----------------------------------------------------
 -- Check that the filter is being pushed down. We create an external table
 -- that returns the filter being sent from the C-side
-CREATE SERVER loopback FOREIGN DATA WRAPPER jdbc_pxf_fdw OPTIONS (jdbc_driver 'org.postgresql.Driver', db_url 'jdbc:postgresql://localhost:5432/gpadmin');
-CREATE USER MAPPING FOR CURRENT_USER SERVER loopback;
-CREATE FOREIGN TABLE foreign_tb_test (id int,  v_text text, v_bool bool) SERVER loopback OPTIONS ( resource 'public.tb_test_t' );
-explain analyze select v_text from foreign_tb_test where v_text = '5' and  v_bool = false ;
-                                                             QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=50000.00..50000.00 rows=1000 width=32) (actual time=25.552..25.554 rows=1 loops=1)
-   ->  Foreign Scan on foreign_tb_test  (cost=50000.00..50000.00 rows=334 width=32) (actual time=0.369..0.371 rows=1 loops=1)
-         Filter: ((NOT v_bool) AND (v_text = '5'::text))
- Planning time: 3.438 ms
-   (slice0)    Executor memory: 59K bytes.
-   (slice1)    Executor memory: 111K bytes avg x 3 workers, 138K bytes max (seg1).
- Memory used:  128000kB
- Optimizer: Postgres query optimizer
- Execution time: 25.723 ms
-(9 rows)
-
-select v_text from foreign_tb_test where v_text = '5' and  v_bool = false ;
- v_text 
---------
- 5
-(1 row)
-
 CREATE FOREIGN DATA WRAPPER pxf_filter_push_down_fdw
     HANDLER pxf_fdw_handler
     VALIDATOR pxf_fdw_validator
@@ -74,6 +51,13 @@ SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
  H  |  7 | f  | a2c16s4dtrueo0l2
  J  |  9 | f  | a2c16s4dtrueo0l2
 (5 rows)
+
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+ t0 | a1 |          filtervalue          
+----+----+-------------------------------
+ B  |  1 | a1c23s1d5o1a2c16s4dtrueo0l2l0
+ D  |  3 | a1c23s1d5o1a2c16s4dtrueo0l2l0
+(2 rows)
 
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
  t0 | a1 | b2 |                 filtervalue                 
@@ -129,6 +113,13 @@ SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
  H  |  7 | f  | a2c16s4dtrueo0l2
  J  |  9 | f  | a2c16s4dtrueo0l2
 (5 rows)
+
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+ t0 | a1 |          filtervalue          
+----+----+-------------------------------
+ B  |  1 | a1c23s1d5o1a2c16s4dtrueo0l2l0
+ D  |  3 | a1c23s1d5o1a2c16s4dtrueo0l2l0
+(2 rows)
 
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
  t0 | a1 | b2 |                 filtervalue                 
@@ -207,6 +198,13 @@ SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
  J  |  9 | f  | a2c16s4dtrueo0l2
 (5 rows)
 
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+ t0 | a1 |          filtervalue          
+----+----+-------------------------------
+ B  |  1 | a1c23s1d5o1a2c16s4dtrueo0l2l0
+ D  |  3 | a1c23s1d5o1a2c16s4dtrueo0l2l0
+(2 rows)
+
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
  t0 | a1 | b2 |                 filtervalue                 
 ----+----+----+---------------------------------------------
@@ -261,6 +259,13 @@ SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
  H  |  7 | f  | a2c16s4dtrueo0l2
  J  |  9 | f  | a2c16s4dtrueo0l2
 (5 rows)
+
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+ t0 | a1 |          filtervalue          
+----+----+-------------------------------
+ B  |  1 | a1c23s1d5o1a2c16s4dtrueo0l2l0
+ D  |  3 | a1c23s1d5o1a2c16s4dtrueo0l2l0
+(2 rows)
 
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
  t0 | a1 | b2 |                 filtervalue                 

--- a/regression/expected/FilterPushDownTest.out
+++ b/regression/expected/FilterPushDownTest.out
@@ -3,29 +3,6 @@
 -----------------------------------------------------
 -- Check that the filter is being pushed down. We create an external table
 -- that returns the filter being sent from the C-side
-create table tb_test_t(id serial primary key,  v_text text, v_bool bool);
-insert into tb_test_t(v_text, v_bool) select v::text, false from generate_series(1, 20) v;
-CREATE EXTERNAL TABLE tb_test_t_pxf(id int,  v_text text, v_bool bool) LOCATION('pxf://public.tb_test_t?PROFILE=JDBC&JDBC_DRIVER=org.postgresql.Driver&DB_URL=jdbc:postgresql://localhost:5432/gpadmin&USER=gpadmin') FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
-explain analyze select v_text from tb_test_t_pxf where v_text = '5' and  v_bool = false ;
-                                                          QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..469.21 rows=237038 width=8) (actual time=12.759..12.760 rows=1 loops=1)
-   ->  External Scan on tb_test_t_pxf  (cost=0.00..462.14 rows=79013 width=8) (actual time=12.051..12.079 rows=1 loops=1)
-         Filter: ((v_text = '5'::text) AND (NOT v_bool))
- Planning time: 6.030 ms
-   (slice0)    Executor memory: 132K bytes.
-   (slice1)    Executor memory: 130K bytes avg x 3 workers, 130K bytes max (seg0).
- Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA)
- Execution time: 13.066 ms
-(9 rows)
-
-select v_text from tb_test_t_pxf where v_text = '5' and  v_bool = false ;
- v_text 
---------
- 5
-(1 row)
-
 DROP EXTERNAL TABLE IF EXISTS test_filter CASCADE;
 CREATE EXTERNAL TABLE test_filter (t0 text, a1 integer, b2 boolean, filterValue text)
     LOCATION (E'pxf://dummy_path?FRAGMENTER=org.greenplum.pxf.diagnostic.FilterVerifyFragmenter&ACCESSOR=org.greenplum.pxf.diagnostic.UserDataVerifyAccessor&RESOLVER=org.greenplum.pxf.plugins.hdfs.StringPassResolver')
@@ -67,6 +44,13 @@ SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
  H  |  7 | f  | a2c16s4dtrueo0l2
  J  |  9 | f  | a2c16s4dtrueo0l2
 (5 rows)
+
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+ t0 | a1 |          filtervalue
+----+----+-------------------------------
+ B  |  1 | a2c16s4dtrueo0l2a1c23s1d5o1l0
+ D  |  3 | a2c16s4dtrueo0l2a1c23s1d5o1l0
+(2 rows)
 
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
  t0 | a1 | b2 |                 filtervalue                 
@@ -122,6 +106,13 @@ SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
  H  |  7 | f  | a2c16s4dtrueo0l2
  J  |  9 | f  | a2c16s4dtrueo0l2
 (5 rows)
+
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+ t0 | a1 |          filtervalue
+----+----+-------------------------------
+ B  |  1 | a1c23s1d5o1a2c16s4dtrueo0l2l0
+ D  |  3 | a1c23s1d5o1a2c16s4dtrueo0l2l0
+(2 rows)
 
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
  t0 | a1 | b2 |                 filtervalue                 
@@ -197,6 +188,13 @@ SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
  J  |  9 | f  | a2c16s4dtrueo0l2
 (5 rows)
 
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+ t0 | a1 |          filtervalue
+----+----+-------------------------------
+ B  |  1 | a2c16s4dtrueo0l2a1c23s1d5o1l0
+ D  |  3 | a2c16s4dtrueo0l2a1c23s1d5o1l0
+(2 rows)
+
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
  t0 | a1 | b2 |                 filtervalue                 
 ----+----+----+---------------------------------------------
@@ -251,6 +249,13 @@ SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
  H  |  7 | f  | a2c16s4dtrueo0l2
  J  |  9 | f  | a2c16s4dtrueo0l2
 (5 rows)
+
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+ t0 | a1 |          filtervalue
+----+----+-------------------------------
+ B  |  1 | a2c16s4dtrueo0l2a1c23s1d5o1l0
+ D  |  3 | a2c16s4dtrueo0l2a1c23s1d5o1l0
+(2 rows)
 
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
  t0 | a1 | b2 |                 filtervalue                 

--- a/regression/expected/FilterPushDownTest.out
+++ b/regression/expected/FilterPushDownTest.out
@@ -3,6 +3,29 @@
 -----------------------------------------------------
 -- Check that the filter is being pushed down. We create an external table
 -- that returns the filter being sent from the C-side
+create table tb_test_t(id serial primary key,  v_text text, v_bool bool);
+insert into tb_test_t(v_text, v_bool) select v::text, false from generate_series(1, 20) v;
+CREATE EXTERNAL TABLE tb_test_t_pxf(id int,  v_text text, v_bool bool) LOCATION('pxf://public.tb_test_t?PROFILE=JDBC&JDBC_DRIVER=org.postgresql.Driver&DB_URL=jdbc:postgresql://localhost:5432/gpadmin&USER=gpadmin') FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
+explain analyze select v_text from tb_test_t_pxf where v_text = '5' and  v_bool = false ;
+                                                          QUERY PLAN
+-------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..469.21 rows=237038 width=8) (actual time=12.759..12.760 rows=1 loops=1)
+   ->  External Scan on tb_test_t_pxf  (cost=0.00..462.14 rows=79013 width=8) (actual time=12.051..12.079 rows=1 loops=1)
+         Filter: ((v_text = '5'::text) AND (NOT v_bool))
+ Planning time: 6.030 ms
+   (slice0)    Executor memory: 132K bytes.
+   (slice1)    Executor memory: 130K bytes avg x 3 workers, 130K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Execution time: 13.066 ms
+(9 rows)
+
+select v_text from tb_test_t_pxf where v_text = '5' and  v_bool = false ;
+ v_text 
+--------
+ 5
+(1 row)
+
 DROP EXTERNAL TABLE IF EXISTS test_filter CASCADE;
 CREATE EXTERNAL TABLE test_filter (t0 text, a1 integer, b2 boolean, filterValue text)
     LOCATION (E'pxf://dummy_path?FRAGMENTER=org.greenplum.pxf.diagnostic.FilterVerifyFragmenter&ACCESSOR=org.greenplum.pxf.diagnostic.UserDataVerifyAccessor&RESOLVER=org.greenplum.pxf.plugins.hdfs.StringPassResolver')

--- a/regression/sql/FDW_FilterPushDownTest.sql
+++ b/regression/sql/FDW_FilterPushDownTest.sql
@@ -5,13 +5,6 @@
 
 -- Check that the filter is being pushed down. We create an external table
 -- that returns the filter being sent from the C-side
-
-CREATE SERVER loopback FOREIGN DATA WRAPPER jdbc_pxf_fdw OPTIONS (jdbc_driver 'org.postgresql.Driver', db_url 'jdbc:postgresql://localhost:5432/gpadmin');
-CREATE USER MAPPING FOR CURRENT_USER SERVER loopback;
-CREATE FOREIGN TABLE foreign_tb_test (id int,  v_text text, v_bool bool) SERVER loopback OPTIONS ( resource 'public.tb_test_t' );
-explain analyze select v_text from foreign_tb_test where v_text = '5' and  v_bool = false ;
-select v_text from foreign_tb_test where v_text = '5' and  v_bool = false ;
-
 CREATE FOREIGN DATA WRAPPER pxf_filter_push_down_fdw
     HANDLER pxf_fdw_handler
     VALIDATOR pxf_fdw_validator
@@ -40,6 +33,8 @@ SELECT * FROM test_filter WHERE  t0 = 'B' OR (a1 >= 0 AND a1 <= 2) ORDER BY t0, 
 
 SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
 
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
 
 SELECT * FROM test_filter WHERE  b2 = false OR (a1 >= 0 AND a1 <= 2) ORDER BY t0, a1;
@@ -55,6 +50,8 @@ SELECT * FROM test_filter WHERE  t0 = 'B' AND (a1 = 1 OR a1 = 10) ORDER BY t0, a
 SELECT * FROM test_filter WHERE  t0 = 'B' OR (a1 >= 0 AND a1 <= 2) ORDER BY t0, a1;
 
 SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
+
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
 
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
 
@@ -98,6 +95,8 @@ SELECT * FROM test_filter WHERE  t0 = 'B' OR (a1 >= 0 AND a1 <= 2) ORDER BY t0, 
 
 SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
 
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
 
 SELECT * FROM test_filter WHERE  b2 = false OR (a1 >= 0 AND a1 <= 2) ORDER BY t0, a1;
@@ -113,6 +112,8 @@ SELECT * FROM test_filter WHERE  t0 = 'B' AND (a1 = 1 OR a1 = 10) ORDER BY t0, a
 SELECT * FROM test_filter WHERE  t0 = 'B' OR (a1 >= 0 AND a1 <= 2) ORDER BY t0, a1;
 
 SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
+
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
 
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
 

--- a/regression/sql/FDW_FilterPushDownTest.sql
+++ b/regression/sql/FDW_FilterPushDownTest.sql
@@ -6,6 +6,12 @@
 -- Check that the filter is being pushed down. We create an external table
 -- that returns the filter being sent from the C-side
 
+CREATE SERVER loopback FOREIGN DATA WRAPPER jdbc_pxf_fdw OPTIONS (jdbc_driver 'org.postgresql.Driver', db_url 'jdbc:postgresql://localhost:5432/gpadmin');
+CREATE USER MAPPING FOR CURRENT_USER SERVER loopback;
+CREATE FOREIGN TABLE foreign_tb_test (id int,  v_text text, v_bool bool) SERVER loopback OPTIONS ( resource 'public.tb_test_t' );
+explain analyze select v_text from foreign_tb_test where v_text = '5' and  v_bool = false ;
+select v_text from foreign_tb_test where v_text = '5' and  v_bool = false ;
+
 CREATE FOREIGN DATA WRAPPER pxf_filter_push_down_fdw
     HANDLER pxf_fdw_handler
     VALIDATOR pxf_fdw_validator

--- a/regression/sql/FilterPushDownTest.sql
+++ b/regression/sql/FilterPushDownTest.sql
@@ -6,12 +6,6 @@
 -- Check that the filter is being pushed down. We create an external table
 -- that returns the filter being sent from the C-side
 
-create table tb_test_t(id serial primary key,  v_text text, v_bool bool);
-insert into tb_test_t(v_text, v_bool) select v::text, false from generate_series(1, 20) v;
-CREATE EXTERNAL TABLE tb_test_t_pxf(id int,  v_text text, v_bool bool) LOCATION('pxf://public.tb_test_t?PROFILE=JDBC&JDBC_DRIVER=org.postgresql.Driver&DB_URL=jdbc:postgresql://localhost:5432/gpadmin&USER=gpadmin') FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
-explain analyze select v_text from tb_test_t_pxf where v_text = '5' and  v_bool = false ;
-select v_text from tb_test_t_pxf where v_text = '5' and  v_bool = false ;
-
 DROP EXTERNAL TABLE IF EXISTS test_filter CASCADE;
 
 CREATE EXTERNAL TABLE test_filter (t0 text, a1 integer, b2 boolean, filterValue text)
@@ -31,6 +25,8 @@ SELECT * FROM test_filter WHERE  t0 = 'B' OR (a1 >= 0 AND a1 <= 2) ORDER BY t0, 
 
 SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
 
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
 
 SELECT * FROM test_filter WHERE  b2 = false OR (a1 >= 0 AND a1 <= 2) ORDER BY t0, a1;
@@ -46,6 +42,8 @@ SELECT * FROM test_filter WHERE  t0 = 'B' AND (a1 = 1 OR a1 = 10) ORDER BY t0, a
 SELECT * FROM test_filter WHERE  t0 = 'B' OR (a1 >= 0 AND a1 <= 2) ORDER BY t0, a1;
 
 SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
+
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
 
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
 
@@ -84,6 +82,8 @@ SELECT * FROM test_filter WHERE  t0 = 'B' OR (a1 >= 0 AND a1 <= 2) ORDER BY t0, 
 
 SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
 
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
 
 SELECT * FROM test_filter WHERE  b2 = false OR (a1 >= 0 AND a1 <= 2) ORDER BY t0, a1;
@@ -99,6 +99,8 @@ SELECT * FROM test_filter WHERE  t0 = 'B' AND (a1 = 1 OR a1 = 10) ORDER BY t0, a
 SELECT * FROM test_filter WHERE  t0 = 'B' OR (a1 >= 0 AND a1 <= 2) ORDER BY t0, a1;
 
 SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
+
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
 
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
 

--- a/regression/sql/FilterPushDownTest.sql
+++ b/regression/sql/FilterPushDownTest.sql
@@ -6,6 +6,12 @@
 -- Check that the filter is being pushed down. We create an external table
 -- that returns the filter being sent from the C-side
 
+create table tb_test_t(id serial primary key,  v_text text, v_bool bool);
+insert into tb_test_t(v_text, v_bool) select v::text, false from generate_series(1, 20) v;
+CREATE EXTERNAL TABLE tb_test_t_pxf(id int,  v_text text, v_bool bool) LOCATION('pxf://public.tb_test_t?PROFILE=JDBC&JDBC_DRIVER=org.postgresql.Driver&DB_URL=jdbc:postgresql://localhost:5432/gpadmin&USER=gpadmin') FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
+explain analyze select v_text from tb_test_t_pxf where v_text = '5' and  v_bool = false ;
+select v_text from tb_test_t_pxf where v_text = '5' and  v_bool = false ;
+
 DROP EXTERNAL TABLE IF EXISTS test_filter CASCADE;
 
 CREATE EXTERNAL TABLE test_filter (t0 text, a1 integer, b2 boolean, filterValue text)


### PR DESCRIPTION
Query on pxf external tables or pxf fdw does not correct work with bool variable pushdown. When pushdowning the results filtered twice: once - on remote pxf part and again - in local gpdb part. But if bool variable is not in select-statement and is in where-statement, then it is not returned from remote pxf part and local gpdb part can not filter by it. This leads to incorrect results.
Steps to reproduce this problem on external table:
```sql
create table tb_test_t(id serial primary key,  v_text text, v_bool bool);
insert into tb_test_t(v_text, v_bool) select v::text, false from generate_series(1, 20) v;
create extension pxf;
CREATE EXTERNAL TABLE tb_test_t_pxf(id int,  v_text text, v_bool bool) LOCATION('pxf://public.tb_test_t?PROFILE=JDBC') FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
explain analyze select v_text from tb_test_t_pxf where v_text = '5' and  v_bool = false ;
select v_text from tb_test_t_pxf where v_text = '5' and  v_bool = false ;
                                                           QUERY PLAN                                                            
---------------------------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..469.21 rows=237038 width=8) (actual time=100.480..100.480 rows=0 loops=1)
   ->  External Scan on tb_test_t_pxf  (cost=0.00..462.14 rows=79013 width=8) (never executed)
         Filter: ((v_text = '5'::text) AND (NOT v_bool))
 Planning time: 47.138 ms
   (slice0)    Executor memory: 132K bytes.
   (slice1)    Executor memory: 130K bytes avg x 3 workers, 130K bytes max (seg0).
 Memory used:  128000kB
 Optimizer: Pivotal Optimizer (GPORCA)
 Execution time: 107.201 ms
(9 rows)
INFO:  extractPxfAttributes: unsupported node tag 303, unable to extract attribute from qualifier  (seg0 slice1 172.19.0.2:5434 pid=7094)
CONTEXT:  External table tb_test_t_pxf
INFO:  extractPxfAttributes: unsupported node tag 303, unable to extract attribute from qualifier  (seg1 slice1 172.19.0.2:5435 pid=7095)
CONTEXT:  External table tb_test_t_pxf
INFO:  extractPxfAttributes: unsupported node tag 303, unable to extract attribute from qualifier  (seg2 slice1 172.19.0.2:5436 pid=7096)
CONTEXT:  External table tb_test_t_pxf
 v_text 
--------
(0 rows)
```
And on pxf fwd:
```sql
create extension pxf_fdw;
CREATE SERVER loopback FOREIGN DATA WRAPPER jdbc_pxf_fdw OPTIONS (jdbc_driver 'org.postgresql.Driver', db_url 'jdbc:postgresql://localhost:5432/gpdb');
CREATE USER MAPPING FOR CURRENT_USER SERVER loopback;
CREATE FOREIGN TABLE foreign_tb_test (id int,  v_text text, v_bool bool) SERVER loopback OPTIONS ( resource 'public.tb_test_t' );
explain analyze select v_text from foreign_tb_test where v_text = '5' and  v_bool = false ;
select v_text from foreign_tb_test where v_text = '5' and  v_bool = false ;
                                                              QUERY PLAN                                                              
--------------------------------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=50000.00..50000.00 rows=1000 width=32) (actual time=124.892..124.892 rows=0 loops=1)
   ->  Foreign Scan on foreign_tb_test  (cost=50000.00..50000.00 rows=334 width=32) (never executed)
         Filter: ((NOT v_bool) AND (v_text = '5'::text))
 Planning time: 16.251 ms
   (slice0)    Executor memory: 59K bytes.
   (slice1)    Executor memory: 132K bytes avg x 3 workers, 138K bytes max (seg0).
 Memory used:  128000kB
 Optimizer: Postgres query optimizer
 Execution time: 125.806 ms
(9 rows)
 v_text 
--------
(0 rows)
```
This happens because `Filter: (NOT b2)` is `T_BoolExpr` consists of `T_Var` which is not supported by pxf pushdown (before this PR).

The problem for external tables was solved by adding `T_Var` for returning from pxf part, and for fdw was solved by setting WHERE clauses are OK on local.

Also a small bug in external tables (wrong total count of return values) was solved.