### PR TITLE
ADBDEV-2976: SIGSEGV while adb read pxf external table

### DIFF
--- a/external-table/src/libchurl.c
+++ b/external-table/src/libchurl.c
@@ -489,6 +489,7 @@ churl_read(CHURL_HANDLE handle, char *buf, size_t max_size)
 	Assert(!context->upload);
 
 	fill_internal_buffer(context, max_size);
+	check_response(context);
 
 	n = context_buffer->top - context_buffer->bot;
 

--- a/external-table/src/libchurl.c
+++ b/external-table/src/libchurl.c
@@ -473,7 +473,6 @@ churl_read_check_connectivity(CHURL_HANDLE handle)
 	Assert(!context->upload);
 
 	fill_internal_buffer(context, 1);
-	check_response(context);
 }
 
 /*
@@ -489,7 +488,6 @@ churl_read(CHURL_HANDLE handle, char *buf, size_t max_size)
 	Assert(!context->upload);
 
 	fill_internal_buffer(context, max_size);
-	check_response(context);
 
 	n = context_buffer->top - context_buffer->bot;
 
@@ -627,6 +625,8 @@ multi_perform(churl_context *context)
 	if (curl_error != CURLM_OK)
 		elog(ERROR, "internal error: curl_multi_perform failed (%d - %s)",
 			 curl_error, curl_easy_strerror(curl_error));
+
+	check_response(context);
 }
 
 static bool
@@ -653,8 +653,6 @@ flush_internal_buffer(churl_context *context)
 
 		multi_perform(context);
 	}
-
-	check_response(context);
 
 	if ((context->curl_still_running == 0) &&
 		((context_buffer->top - context_buffer->bot) > 0))
@@ -710,8 +708,6 @@ finish_upload(churl_context *context)
 	 */
 	while (context->curl_still_running != 0)
 		multi_perform(context);
-
-	check_response(context);
 }
 
 static void

--- a/fdw/libchurl.c
+++ b/fdw/libchurl.c
@@ -457,7 +457,6 @@ churl_read_check_connectivity(CHURL_HANDLE handle)
 	Assert(!context->upload);
 
 	fill_internal_buffer(context, 1);
-	check_response(context);
 }
 
 /*
@@ -473,7 +472,6 @@ churl_read(CHURL_HANDLE handle, char *buf, size_t max_size)
 	Assert(!context->upload);
 
 	fill_internal_buffer(context, max_size);
-	check_response(context);
 
 	n = context_buffer->top - context_buffer->bot;
 
@@ -611,6 +609,8 @@ multi_perform(churl_context *context)
 	if (curl_error != CURLM_OK)
 		elog(ERROR, "internal error: curl_multi_perform failed (%d - %s)",
 			 curl_error, curl_easy_strerror(curl_error));
+
+	check_response(context);
 }
 
 bool
@@ -641,8 +641,6 @@ flush_internal_buffer(churl_context *context)
 	if ((context->curl_still_running == 0) &&
 		((context_buffer->top - context_buffer->bot) > 0))
 		elog(ERROR, "failed sending to remote component %s", get_dest_address(context->curl_handle));
-
-	check_response(context);
 
 	context_buffer->top = 0;
 	context_buffer->bot = 0;
@@ -695,8 +693,6 @@ finish_upload(churl_context *context)
 	 */
 	while (context->curl_still_running != 0)
 		multi_perform(context);
-
-	check_response(context);
 }
 
 void

--- a/fdw/libchurl.c
+++ b/fdw/libchurl.c
@@ -473,6 +473,7 @@ churl_read(CHURL_HANDLE handle, char *buf, size_t max_size)
 	Assert(!context->upload);
 
 	fill_internal_buffer(context, max_size);
+	check_response(context);
 
 	n = context_buffer->top - context_buffer->bot;
 


### PR DESCRIPTION
pxf may not catch malformed chunked encoded response

Steps to reproduce problem:
1) run script (`tcpserver` from `ucspi-tcp`)
```sh
tcpserver -D -H -R -v 0.0.0.0 5888 stdbuf -o 0 ./cmd.sh
```
where `cmd.sh` content is
```sh
#!/bin/bash -eux

echo -en 'HTTP/1.1 200 OK'
echo -en '\r\n'
echo -en 'Transfer-Encoding: chunked'
echo -en '\r\n'
echo -en '\r\n'

echo -en '1e'
echo -en '\r\n'
echo -en 'fragment3 row1,value1,value2'
echo -en '\r\n'
echo -en '\r\n'

echo -en '1e'
echo -en '\r\n'
echo -en 'fragment3 row2,value1,value2'
echo -en '\r\n'
echo -en '\r\n'

echo -en '1e'
echo -en '\r\n'
echo -en 'fragment3 row1,value1,value2'
echo -en '\rqwe\n'
echo -en '\r\n'

echo -en '1e'
echo -en '\r\n'
echo -en 'fragment3 row2,value1,value2'
echo -en '\r\n'
echo -en '\r\n'

echo -en '0'
echo -en '\r0\n'
echo -en '\r\n'
```
2) use `curl 7.29.0` on `gpdb 6.3.0_arenadata1` with
```diff
diff --git a/external-table/src/pxfbridge.c b/external-table/src/pxfbridge.c
index 713c1d30..425781cf 100644
--- a/external-table/src/pxfbridge.c
+++ b/external-table/src/pxfbridge.c
@@ -103,6 +103,10 @@ gpbridge_read(gphadoop_context *context, char *databuf, int datalen)
                /* check if the connection terminated with an error */
                churl_read_check_connectivity(context->churl_handle);
        }
+       else
+       {
+               elog(WARNING, "databuf = %*.*s", (int)n, (int)n, databuf);
+       }
 
        elog(DEBUG5, "pxf gpbridge_read: segment %d read %zu bytes from %s",
                 GpIdentity.segindex, n, context->gphd_uri->data);
```
3) execute
```sql
CREATE EXTERNAL TABLE pxf_read_test (a TEXT, b TEXT, c TEXT) LOCATION ('pxf://localhost:5888/tmp/dummy1?FRAGMENTER=org.greenplum.pxf.api.examples.DemoFragmenter&ACCESSOR=org.greenplum.pxf.api.examples.DemoAccessor&RESOLVER=org.greenplum.pxf.api.examples.DemoTextResolver') FORMAT 'TEXT' (DELIMITER ',');
select * from pxf_read_test;
WARNING:  databuf = fragment3 row1,value1,value2
fragment3 row2,value1,value2
q  (seg0 slice1 172.19.0.3:6434 pid=30014)
CONTEXT:  External table pxf_read_test, line 1 of file pxf://localhost:5888/tmp/dummy1?FRAGMENTER=org.greenplum.pxf.api.examples.DemoFragmenter&ACCESSOR=org.greenplum.pxf.api.examples.DemoAccessor&RESOLVER=org.greenplum.pxf.api.examples.DemoTextResolver
WARNING:  databuf = fragment3 row1,value1,value2
fragment3 row2,value1,value2
q  (seg1 slice1 172.19.0.3:6435 pid=30015)
CONTEXT:  External table pxf_read_test, line 1 of file pxf://localhost:5888/tmp/dummy1?FRAGMENTER=org.greenplum.pxf.api.examples.DemoFragmenter&ACCESSOR=org.greenplum.pxf.api.examples.DemoAccessor&RESOLVER=org.greenplum.pxf.api.examples.DemoTextResolver
WARNING:  databuf = fragment3 row1,value1,value2
fragment3 row2,value1,value2
q  (seg2 slice1 172.19.0.3:6436 pid=30016)
CONTEXT:  External table pxf_read_test, line 1 of file pxf://localhost:5888/tmp/dummy1?FRAGMENTER=org.greenplum.pxf.api.examples.DemoFragmenter&ACCESSOR=org.greenplum.pxf.api.examples.DemoAccessor&RESOLVER=org.greenplum.pxf.api.examples.DemoTextResolver
ERROR:  transfer error (56): Failure when receiving data from the peer from '127.0.0.1:5888' (libchurl.c:928)  (seg0 slice1 172.19.0.3:6434 pid=30014) (libchurl.c:928)
DETAIL:  curl error buffer: Problem (3) in the Chunked-Encoded data
CONTEXT:  External table pxf_read_test, line 3 of file pxf://localhost:5888/tmp/dummy1?FRAGMENTER=org.greenplum.pxf.api.examples.DemoFragmenter&ACCESSOR=org.greenplum.pxf.api.examples.DemoAccessor&RESOLVER=org.greenplum.pxf.api.examples.DemoTextResolver
```
It happens because `msg->extmsg.data.result` may be rewritten in `multi_runsingle`.
To solve this problem I add check response after fill internal buffer
```sql
select * from pxf_read_test;
ERROR:  transfer error (56): Failure when receiving data from the peer from '127.0.0.1:5888' (libchurl.c:928)  (seg0 slice1 172.19.0.3:6434 pid=29267) (libchurl.c:928)
DETAIL:  curl error buffer: Problem (3) in the Chunked-Encoded data
CONTEXT:  External table pxf_read_test, line 1 of file pxf://localhost:5888/tmp/dummy1?FRAGMENTER=org.greenplum.pxf.api.examples.DemoFragmenter&ACCESSOR=org.greenplum.pxf.api.examples.DemoAccessor&RESOLVER=org.greenplum.pxf.api.examples.DemoTextResolver
```