### PR TITLE
pxf-6.x/ADBDEV-3104: Add close connection if something wrong in openForRead() method

### DIFF
--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcBasePlugin.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcBasePlugin.java
@@ -488,7 +488,7 @@ public class JdbcBasePlugin extends BasePlugin {
      * @param connection connection to close
      * @throws SQLException throws when a SQLException occurs
      */
-    private static void closeConnection(Connection connection) throws SQLException {
+    static void closeConnection(Connection connection) throws SQLException {
         if (connection == null) {
             LOG.warn("Call to close connection is ignored as connection provided was null");
             return;

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcAccessorTest.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcAccessorTest.java
@@ -82,7 +82,7 @@ public class JdbcAccessorTest {
         context.setDataSource("query:foo");
         accessor.setRequestContext(context);
         accessor.afterPropertiesSet();
-        Exception e = assertThrows(IllegalStateException.class,
+        Exception e = assertThrows(RuntimeException.class,
                 () -> accessor.openForRead());
         assertEquals("No server configuration directory found for server unknown", e.getMessage());
     }


### PR DESCRIPTION
This commit adds close connection if something wrong in openForRead() method. 
The problem is that if `statementRead == null` the connection will not be closed and will remain open.
One of the case to reproduce the issue is to use named query. If the file with the query does not exist on the segment the connection will be opened but the `statementRead` will be null. In this case the connection will not be closed:
```java
if (statement == null) {
    LOG.warn("Call to close statement and connection is ignored as statement provided was null");
    return;
}
```