### PR TITLE
ADBDEV-3208: Add pxf command to encrypt password

### DIFF
--- a/server/pxf-service/src/scripts/pxf
+++ b/server/pxf-service/src/scripts/pxf
@@ -507,15 +507,15 @@ function doEncrypt()
     if [[ -z $conf_file ]]; then
         fail "File 'pxf-application.properties' was not found in PXF_BASE/conf/ directory"
     fi
-    jarfile=$(find "$PXF_BASE/lib" -maxdepth 1 -type f -name 'encryption-*.jar')
-    if [[ -z $jarfile ]]; then
+    encr_jar_file=$(find "$PXF_BASE/lib" -maxdepth 1 -type f -name 'encryption-*.jar')
+    if [[ -z $encr_jar_file ]]; then
         fail "Encryption library was not found in $PXF_BASE/lib/ directory"
     fi
     jksPath=$(getProperty 'pxf.ssl.jks-store.path' "$conf_file")
     jksPassword=$(getProperty 'pxf.ssl.jks-store.password' "$conf_file")
     jksEncryptKeyAlias=$(getProperty 'pxf.ssl.salt.key' "$conf_file")
     checkJavaHome
-    java -jar $jarfile -command encrypt -jksPath $jksPath -jksPassword $jksPassword -jksEncryptKeyAlias $jksEncryptKeyAlias -message $pwd -encryptorType $encryptorType
+    java -jar $encr_jar_file -command encrypt -jksPath $jksPath -jksPassword $jksPassword -jksEncryptKeyAlias $jksEncryptKeyAlias -message $pwd -encryptorType $encryptorType
 }
 
 function getProperty {

--- a/server/pxf-service/src/scripts/pxf
+++ b/server/pxf-service/src/scripts/pxf
@@ -505,7 +505,7 @@ function doEncrypt()
     fi
     conf_file="$PXF_BASE/conf/pxf-application.properties"
     if [[ -z $conf_file ]]; then
-        fail "File 'pxf-application.propertie' was not found in PXF_BASE/conf/ directory"
+        fail "File 'pxf-application.properties' was not found in PXF_BASE/conf/ directory"
     fi
     jarfile=$(find "$PXF_BASE/lib" -maxdepth 1 -type f -name 'encryption-*.jar')
     if [[ -z $jarfile ]]; then

--- a/server/pxf-service/src/scripts/pxf
+++ b/server/pxf-service/src/scripts/pxf
@@ -227,6 +227,7 @@ function doHelp()
 	                      It creates the servers, logs, lib, keytabs, and run directories inside \$PXF_BASE
 	                      and copies configuration files.
 	  migrate             migrates configurations from older installations of PXF
+	  encrypt <password> <encryptor_type>     encrypt password with specified encryptor type. Default encryptor type is aes256
 	  cluster <command>   perform <command> on all the segment hosts in the cluster; try ${bold}pxf cluster help$normal
 
 	  sync <hostname>     synchronize \$PXF_BASE/{conf,lib,servers} directories onto <hostname>. Use --delete to delete extraneous remote files
@@ -492,6 +493,35 @@ function doSync()
     rsync -az${DELETE:+ --delete} -e "ssh -o StrictHostKeyChecking=no" "$PXF_BASE"/{conf,lib,servers} "${target_host}:$PXF_BASE"
 }
 
+function doEncrypt()
+{
+    local pwd=$1
+    local encryptorType=$2
+    if [[ -z $pwd ]]; then
+        fail 'Please provide password you want to encrypt'
+    fi
+    if [[ -z $encryptorType ]]; then
+        encryptorType=aes256
+    fi
+    conf_file="$PXF_BASE/conf/pxf-application.properties"
+    if [[ -z $conf_file ]]; then
+        fail "File 'pxf-application.propertie' was not found in PXF_BASE/conf/ directory"
+    fi
+    jarfile=$(find "$PXF_BASE/lib" -maxdepth 1 -type f -name 'encryption-*.jar')
+    if [[ -z $jarfile ]]; then
+        fail "Encryption library was not found in $PXF_BASE/lib/ directory"
+    fi
+    jksPath=$(getProperty 'pxf.ssl.jks-store.path' "$conf_file")
+    jksPassword=$(getProperty 'pxf.ssl.jks-store.password' "$conf_file")
+    jksEncryptKeyAlias=$(getProperty 'pxf.ssl.salt.key' "$conf_file")
+    checkJavaHome
+    java -jar $jarfile -command encrypt -jksPath $jksPath -jksPassword $jksPassword -jksEncryptKeyAlias $jksEncryptKeyAlias -message $pwd -encryptorType $encryptorType
+}
+
+function getProperty {
+    grep "^${1}" ${2} | cut -d'=' -f2
+}
+
 function doCluster()
 {
     local cmd=$2
@@ -544,6 +574,9 @@ case $pxf_script_command in
         else
             doSync "$2"
         fi
+        ;;
+    'encrypt')
+        doEncrypt "$2" "$3"
         ;;
     'help' | '-h' | '--help')
         doHelp


### PR DESCRIPTION
Before use this future we must put execution jar-file of our encryption library into the  $PXF_BASE/lib directory.