### PR TITLE
PXF Docker environment for tests running

### DIFF
--- a/arenadata/Dockerfile
+++ b/arenadata/Dockerfile
@@ -1,0 +1,29 @@
+FROM hub.adsw.io/library/gpdb6_regress:latest as base
+
+# install java, go, ginkgo and keep env variables which may be used as a part of base image
+RUN yum install -y go
+ENV GOPATH=$HOME/go
+ENV PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
+RUN go install github.com/onsi/ginkgo/ginkgo@latest
+
+# leave pxf artifacts dir env also
+ENV OUTPUT_ARTIFACT_DIR="pxf_tarball"
+
+COPY . /tmp/build/pxf_src
+
+# create separate image with files we don't want to keep in base image
+FROM base as build
+WORKDIR /home/gpadmin
+RUN source gpdb_src/concourse/scripts/common.bash && \
+    install_gpdb
+
+WORKDIR /tmp/build
+RUN source '/usr/local/greenplum-db-devel/greenplum_path.sh' && \
+    mkdir /tmp/build/${OUTPUT_ARTIFACT_DIR} && \
+    pxf_src/concourse/scripts/compile_pxf.bash
+
+# create test image which prepares base image and keeps only pxf artifacts from build image
+FROM base as test
+RUN rm /home/gpadmin/bin_gpdb/server-*.tar.gz
+RUN rm -rf /tmp/build/pxf_src/.git/
+COPY --from=build /tmp/build/${OUTPUT_ARTIFACT_DIR}/pxf.tar.gz /tmp/build/${OUTPUT_ARTIFACT_DIR}/

--- a/arenadata/Dockerfile
+++ b/arenadata/Dockerfile
@@ -15,11 +15,12 @@ RUN rm /home/gpadmin/bin_gpdb/server-*.tar.gz && \
     mkdir /tmp/build && \
     ln -s /home/gpadmin/gpdb_src /tmp/build/gpdb_src && \
     ln -s /home/gpadmin/bin_gpdb /tmp/build/bin_gpdb
+# default working dir - the place where all sources and artifacts are placed
+WORKDIR /tmp/build
 
 # create separate image with files we don't want to keep in base image
 FROM base as build
 COPY . /tmp/build/pxf_src
-WORKDIR /tmp/build
 RUN source gpdb_src/concourse/scripts/common.bash && \
     install_gpdb && \
     source '/usr/local/greenplum-db-devel/greenplum_path.sh' && \

--- a/arenadata/Dockerfile
+++ b/arenadata/Dockerfile
@@ -1,6 +1,6 @@
 FROM hub.adsw.io/library/gpdb6_regress:latest as base
 
-# install java, go, ginkgo and keep env variables which may be used as a part of base image
+# install go, ginkgo and keep env variables which may be used as a part of base image
 RUN yum install -y go
 ENV GOPATH=$HOME/go
 ENV PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
@@ -9,21 +9,24 @@ RUN go install github.com/onsi/ginkgo/ginkgo@latest
 # leave pxf artifacts dir env also
 ENV OUTPUT_ARTIFACT_DIR="pxf_tarball"
 
-COPY . /tmp/build/pxf_src
+# remove unnecessary artifacts and create symlinks
+# concource scripts expects gpdb and pxf placed in the same folder
+RUN rm /home/gpadmin/bin_gpdb/server-*.tar.gz && \
+    mkdir /tmp/build && \
+    ln -s /home/gpadmin/gpdb_src /tmp/build/gpdb_src && \
+    ln -s /home/gpadmin/bin_gpdb /tmp/build/bin_gpdb
 
 # create separate image with files we don't want to keep in base image
 FROM base as build
-WORKDIR /home/gpadmin
-RUN source gpdb_src/concourse/scripts/common.bash && \
-    install_gpdb
-
+COPY . /tmp/build/pxf_src
 WORKDIR /tmp/build
-RUN source '/usr/local/greenplum-db-devel/greenplum_path.sh' && \
-    mkdir /tmp/build/${OUTPUT_ARTIFACT_DIR} && \
+RUN source gpdb_src/concourse/scripts/common.bash && \
+    install_gpdb && \
+    source '/usr/local/greenplum-db-devel/greenplum_path.sh' && \
+    mkdir ${OUTPUT_ARTIFACT_DIR} && \
     pxf_src/concourse/scripts/compile_pxf.bash
 
 # create test image which prepares base image and keeps only pxf artifacts from build image
 FROM base as test
-RUN rm /home/gpadmin/bin_gpdb/server-*.tar.gz
-RUN rm -rf /tmp/build/pxf_src/.git/
 COPY --from=build /tmp/build/${OUTPUT_ARTIFACT_DIR}/pxf.tar.gz /tmp/build/${OUTPUT_ARTIFACT_DIR}/
+COPY --from=build /tmp/build/pxf_src /tmp/build/pxf_src

--- a/arenadata/README.md
+++ b/arenadata/README.md
@@ -1,0 +1,15 @@
+## How to build PXF Docker image
+From the root pxf folder run:
+```bash
+docker build -t gpdb6_pxf_regress:latest -f arenadata/Dockerfile .
+```
+This will build an image called `gpdb6_pxf_regress` with the tag `latest`. This image is based on `gpdb6_regress:latest`, which additionally contains pxf sources and pxf artifacts tarball in `/tmp/build/pxf_src` and `/tmp/build/pxf_tarball` folders respectively.
+
+## How to test PXF
+During the image building phase `compile_pxf.bash` script additionally calls `test` make target, which calls `make -C cli/go/src/pxf-cli test` and `make -C server test` commands.
+To additionally test `fdw` and `external-table` parts you may call:
+```bash
+docker run --rm -it \
+  --privileged --sysctl kernel.sem="500 1024000 200 4096" \
+  gpdb6_pxf_regress:latest /tmp/build/pxf_src/arenadata/test_in_docker.sh
+```

--- a/arenadata/test_in_docker.sh
+++ b/arenadata/test_in_docker.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# This script depends on hub.adsw.io/library/gpdb6_pxf_regress
+
+# manually prepare gpadmin user; test_pxf.bash doesn't tweak gpadmin folder permissions and ssh keys
+./gpdb_src/concourse/scripts/setup_gpadmin_user.bash
+# test_pxf.bash use relative paths for unpacking gpdb commands and sourcing of env vars
+cd /tmp/build
+ln -s /home/gpadmin/gpdb_src /tmp/build/gpdb_src 
+ln -s /home/gpadmin/bin_gpdb /tmp/build/bin_gpdb
+# unpack gpdb and pxf; run gpdb cluster and pxf server
+pxf_src/concourse/scripts/test_pxf.bash
+# tweak necessary folders to run regression tests later
+chown gpadmin:gpadmin -R /usr/local/greenplum-db-devel
+chown gpadmin:gpadmin -R /tmp/build/pxf_src
+
+# test fdw and external-table
+su - gpadmin -c "
+    source '/usr/local/greenplum-db-devel/greenplum_path.sh';
+    source '/home/gpadmin/gpdb_src/gpAux/gpdemo/gpdemo-env.sh';
+    cd /tmp/build/pxf_src/fdw &&
+    make install &&
+    make installcheck &&
+    cd ../external-table/ &&
+    make install &&
+    make installcheck;
+"

--- a/arenadata/test_in_docker.sh
+++ b/arenadata/test_in_docker.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # This script depends on hub.adsw.io/library/gpdb6_pxf_regress
+set -exo pipefail
 
 # manually prepare gpadmin user; test_pxf.bash doesn't tweak gpadmin folder permissions and ssh keys
 ./gpdb_src/concourse/scripts/setup_gpadmin_user.bash

--- a/arenadata/test_in_docker.sh
+++ b/arenadata/test_in_docker.sh
@@ -3,12 +3,8 @@
 
 # manually prepare gpadmin user; test_pxf.bash doesn't tweak gpadmin folder permissions and ssh keys
 ./gpdb_src/concourse/scripts/setup_gpadmin_user.bash
-# test_pxf.bash use relative paths for unpacking gpdb commands and sourcing of env vars
-cd /tmp/build
-ln -s /home/gpadmin/gpdb_src /tmp/build/gpdb_src 
-ln -s /home/gpadmin/bin_gpdb /tmp/build/bin_gpdb
 # unpack gpdb and pxf; run gpdb cluster and pxf server
-pxf_src/concourse/scripts/test_pxf.bash
+/tmp/build/pxf_src/concourse/scripts/test_pxf.bash
 # tweak necessary folders to run regression tests later
 chown gpadmin:gpadmin -R /usr/local/greenplum-db-devel
 chown gpadmin:gpadmin -R /tmp/build/pxf_src

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/examples/DemoTextResolver.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/examples/DemoTextResolver.java
@@ -23,6 +23,8 @@ import org.greenplum.pxf.api.OneField;
 import org.greenplum.pxf.api.OneRow;
 import org.greenplum.pxf.api.io.DataType;
 
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -62,8 +64,16 @@ public class DemoTextResolver extends DemoResolver {
             throw new Exception("Unexpected record format, expected 1 field, found " +
                     (record == null ? 0 : record.size()));
         }
-        byte[] value = (byte[]) record.get(0).val;
+        int readCount;
+        byte[] data = new byte[1024];
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        DataInputStream dis = (DataInputStream) record.get(0).val;
+        while ((readCount = dis.read(data, 0, data.length)) != -1) {
+            buffer.write(data, 0, readCount);
+        }
+        buffer.flush();
+        byte[] bytes= buffer.toByteArray();
         // empty array means the end of input stream, return null to stop iterations
-        return value.length == 0 ? null : new OneRow(value);
+        return bytes.length == 0 ? null : new OneRow(bytes);
     }
 }

--- a/server/pxf-api/src/test/java/org/greenplum/pxf/api/DemoResolverTest.java
+++ b/server/pxf-api/src/test/java/org/greenplum/pxf/api/DemoResolverTest.java
@@ -26,6 +26,8 @@ import org.greenplum.pxf.api.model.RequestContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -55,7 +57,7 @@ public class DemoResolverTest {
         textResolver = new DemoTextResolver();
 
         row = new OneRow("0.0", DATA);
-        field = new OneField(VARCHAR.getOID(), DATA.getBytes());
+        field = new OneField(VARCHAR.getOID(), new DataInputStream(new ByteArrayInputStream(DATA.getBytes())));
     }
 
     @Test
@@ -79,7 +81,7 @@ public class DemoResolverTest {
 
     @Test
     public void testSetEmptyTextData() throws Exception {
-        OneField field = new OneField(VARCHAR.getOID(), new byte[]{});
+        OneField field = new OneField(VARCHAR.getOID(), new DataInputStream(new ByteArrayInputStream(new byte[]{})));
         OneRow output = textResolver.setFields(Collections.singletonList(field));
         assertNull(output);
     }


### PR DESCRIPTION
The goal of this patch is to begin automation of PXF testing. It contains scripts and images for Docker environment, like it's done for other ADB components and extensions. Existing upstream concourse scripts were reused where it was possible. For now, we don't focus on hadoop integration testing, but do unit testing, fdw and external-table regression testing.