### PR TITLE
ADBDEV-3807: Close connection to PXF when query to external table is canceled

### DIFF
--- a/external-table/src/pxfbridge.c
+++ b/external-table/src/pxfbridge.c
@@ -40,7 +40,7 @@ gpbridge_cleanup(gphadoop_context *context)
 	if (context == NULL)
 		return;
 
-	churl_cleanup(context->churl_handle, false);
+	churl_cleanup(context->churl_handle, context->after_error);
 	context->churl_handle = NULL;
 
 	churl_headers_cleanup(context->churl_headers);

--- a/external-table/src/pxfbridge.h
+++ b/external-table/src/pxfbridge.h
@@ -43,6 +43,7 @@ typedef struct
 	ProjectionInfo *proj_info;
 	List           *quals;
 	bool           completed;
+	bool           after_error;
 } gphadoop_context;
 
 /*


### PR DESCRIPTION
The C-part of the PXF releases the context (`cleanup_context`) only on the last call in the `pxfprotocol_export` and `pxfprotocol_import` functions.
That is, on errors, the context is not released, including curl-connections to the Java-part are not closed.
Therefore, I added a callback to release resources on errors, which releases the context, including closing curl-connections.

For example, this may happen when a request is canceled when an exclusive lock has been taken on a table referenced by an external table.
1) create tables
```sql
CREATE EXTENSION pxf;
CREATE TABLE t(a int) DISTRIBUTED BY (a);
INSERT INTO t SELECT i FROM generate_series(1, 1000) i;
CREATE EXTERNAL TABLE e(a int) LOCATION('pxf://t?PROFILE=JDBC&JDBC_DRIVER=org.postgresql.Driver&DB_URL=jdbc:postgresql://localhost:6432/postgres') FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
```
2) in one session, run the command:
```sql
begin;lock table t in ACCESS exclusive mode;
```
and don't close the session.

3) in another session, run the command:
```sql
SELECT count(*) FROM e;
```
and then interrupt its execution with Ctrl+C, but don't close the session.
The connection from the C-part to the Java-part remains:
```sh
bash-4.2$ netstat -enpt | grep :5888
tcp        0      0 127.0.0.1:42236         127.0.0.1:5888          ESTABLISHED 1000       7244695    161781/postgres:  6 
tcp        0      0 127.0.0.1:5888          127.0.0.1:42236         ESTABLISHED 1000       7229437    157250/java         
```
expected (and with patch): adb processes are closed, but Java-part remain:
```sh
bash-4.2$ netstat -enpt | grep :5888
tcp        1      0 127.0.0.1:5888          127.0.0.1:47074         CLOSE_WAIT  1000       6885317    144206/java         
```