### PR TITLE
ADBDEV-4083: Downgrade snappy-java to 1.1.8.4

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -147,7 +147,9 @@ configure(javaProjects) {
             dependency("org.threeten:threeten-extra:1.5.0")
             dependency("org.tukaani:xz:1.8")
             dependency("org.wildfly.openssl:wildfly-openssl:1.0.7.Final")
-            dependency("org.xerial.snappy:snappy-java:1.1.10.1")
+
+            // The snappy-java:1.1.8.4 is required for PPC64LE arch.
+            dependency("org.xerial.snappy:snappy-java:1.1.8.4")
 
             // Arenadata encryption
             dependency("io.arenadata.security:encryption:1.0.0")


### PR DESCRIPTION
The version 1.1.10.1 for the Power arch (PPC64LE) requires GLIBC_2.32 library. But CentOs 7 has 2.17 version and it is almost impossible to update the library in the OS.