### PR TITLE
ADBDEV-4203: Refactor closing connection to pxf, including fdw

### DIFF
--- a/external-table/src/libchurl.c
+++ b/external-table/src/libchurl.c
@@ -23,6 +23,7 @@
 #include "utils/fmgroids.h"
 #include "utils/guc.h"
 #include "utils/jsonapi.h"
+#include "utils/resowner.h"
 
 /* include libcurl without typecheck.
  * This allows wrapping curl_easy_setopt to be wrapped
@@ -46,9 +47,17 @@ typedef struct
 } churl_buffer;
 
 /*
- * internal context of libchurl
+ * holds http header properties
  */
 typedef struct
+{
+	struct curl_slist *headers;
+} churl_settings;
+
+/*
+ * internal context of libchurl
+ */
+typedef struct churl_context
 {
 	/* curl easy API handle */
 	CURL	   *curl_handle;
@@ -57,6 +66,8 @@ typedef struct
 	 * curl multi API handle used to allow non-blocking callbacks
 	 */
 	CURLM	   *multi_handle;
+
+	churl_settings churl_headers;
 
 	/*
 	 * curl API puts internal errors in this buffer used for error reporting
@@ -70,10 +81,10 @@ typedef struct
 	int			curl_still_running;
 
 	/* internal buffer for download */
-	churl_buffer *download_buffer;
+	churl_buffer download_buffer;
 
 	/* internal buffer for upload */
-	churl_buffer *upload_buffer;
+	churl_buffer upload_buffer;
 
 	/*
 	 * holds http error code returned from remote server
@@ -82,15 +93,11 @@ typedef struct
 
 	/* true on upload, false on download */
 	bool		upload;
-} churl_context;
 
-/*
- * holds http header properties
- */
-typedef struct
-{
-	struct curl_slist *headers;
-} churl_settings;
+	ResourceOwner owner; /* owner of this handle */
+	struct churl_context *next;
+	struct churl_context *prev;
+} churl_context;
 
 /* the null action object used for pure validation */
 static JsonSemAction nullSemAction =
@@ -99,7 +106,10 @@ static JsonSemAction nullSemAction =
 	NULL, NULL, NULL, NULL, NULL
 };
 
-churl_context *churl_new_context(void);
+static churl_context *open_curl_handles;
+static bool churl_resowner_callback_registered;
+
+static churl_context *churl_new_context(void);
 static void		create_curl_handle(churl_context *context);
 static void		set_curl_option(churl_context *context, CURLoption option, const void *data);
 static size_t	read_callback(void *ptr, size_t size, size_t nmemb, void *userdata);
@@ -112,7 +122,6 @@ static void		enlarge_internal_buffer(churl_buffer *buffer, size_t required);
 static void		finish_upload(churl_context *context);
 static void		cleanup_curl_handle(churl_context *context);
 static void		multi_remove_handle(churl_context *context);
-static void		cleanup_internal_buffer(churl_buffer *buffer);
 static void		churl_cleanup_context(churl_context *context);
 static size_t	write_callback(char *buffer, size_t size, size_t nitems, void *userp);
 static void		fill_internal_buffer(churl_context *context, int want);
@@ -307,8 +316,6 @@ churl_headers_cleanup(CHURL_HEADERS headers)
 
 	if (settings->headers)
 		curl_slist_free_all(settings->headers);
-
-	pfree(settings);
 }
 
 /*
@@ -352,7 +359,9 @@ log_curl_debug(CURL *handle, curl_infotype type, char *data, size_t size, void *
 static CHURL_HANDLE
 churl_init(const char *url, CHURL_HEADERS headers)
 {
+	churl_settings *settings = headers;
 	churl_context *context = churl_new_context();
+	context->churl_headers.headers = settings->headers;
 
 	create_curl_handle(context);
 	clear_error_buffer(context);
@@ -445,7 +454,7 @@ size_t
 churl_write(CHURL_HANDLE handle, const char *buf, size_t bufsize)
 {
 	churl_context *context = (churl_context *) handle;
-	churl_buffer *context_buffer = context->upload_buffer;
+	churl_buffer *context_buffer = &context->upload_buffer;
 
 	Assert(context->upload);
 
@@ -483,7 +492,7 @@ churl_read(CHURL_HANDLE handle, char *buf, size_t max_size)
 {
 	int			n = 0;
 	churl_context *context = (churl_context *) handle;
-	churl_buffer *context_buffer = context->download_buffer;
+	churl_buffer *context_buffer = &context->download_buffer;
 
 	Assert(!context->upload);
 
@@ -525,18 +534,59 @@ churl_cleanup(CHURL_HANDLE handle, bool after_error)
 	}
 
 	cleanup_curl_handle(context);
-	cleanup_internal_buffer(context->download_buffer);
-	cleanup_internal_buffer(context->upload_buffer);
+	churl_headers_cleanup(&context->churl_headers);
 	churl_cleanup_context(context);
 }
 
-churl_context *
-churl_new_context()
+static void
+churl_abort_callback(ResourceReleasePhase phase,
+						bool isCommit,
+						bool isTopLevel,
+						void *arg)
 {
-	churl_context *context = palloc0(sizeof(churl_context));
+	churl_context *curr;
+	churl_context *next;
 
-	context->download_buffer = palloc0(sizeof(churl_buffer));
-	context->upload_buffer = palloc0(sizeof(churl_buffer));
+	if (phase != RESOURCE_RELEASE_AFTER_LOCKS)
+		return;
+
+	next = open_curl_handles;
+	while (next)
+	{
+		curr = next;
+		next = curr->next;
+
+		if (curr->owner == CurrentResourceOwner)
+		{
+			if (isCommit)
+				elog(LOG, "pxf reference leak: %p still referenced", curr);
+
+			churl_cleanup(curr, !isCommit);
+		}
+	}
+}
+
+static churl_context *
+churl_new_context(void)
+{
+	churl_context *context = MemoryContextAllocZero(TopMemoryContext, sizeof(churl_context));
+
+	context->owner = CurrentResourceOwner;
+
+	if (open_curl_handles)
+	{
+		context->next = open_curl_handles;
+		open_curl_handles->prev = context;
+	}
+
+	open_curl_handles = context;
+
+	if (!churl_resowner_callback_registered)
+	{
+		RegisterResourceReleaseCallback(churl_abort_callback, NULL);
+		churl_resowner_callback_registered = true;
+	}
+
 	return context;
 }
 
@@ -575,7 +625,7 @@ static size_t
 read_callback(void *ptr, size_t size, size_t nmemb, void *userdata)
 {
 	churl_context *context = (churl_context *) userdata;
-	churl_buffer *context_buffer = context->upload_buffer;
+	churl_buffer *context_buffer = &context->upload_buffer;
 
 	int			written = Min(size * nmemb, context_buffer->top - context_buffer->bot);
 
@@ -638,7 +688,7 @@ internal_buffer_large_enough(churl_buffer *buffer, size_t required)
 static void
 flush_internal_buffer(churl_context *context)
 {
-	churl_buffer *context_buffer = context->upload_buffer;
+	churl_buffer *context_buffer = &context->upload_buffer;
 
 	if (context_buffer->top == 0)
 		return;
@@ -737,35 +787,17 @@ multi_remove_handle(churl_context *context)
 }
 
 static void
-cleanup_internal_buffer(churl_buffer *buffer)
-{
-	if ((buffer) && (buffer->ptr))
-	{
-		pfree(buffer->ptr);
-		buffer->ptr = NULL;
-		buffer->bot = 0;
-		buffer->top = 0;
-		buffer->max = 0;
-	}
-}
-
-static void
 churl_cleanup_context(churl_context *context)
 {
 	if (context)
 	{
-		if (context->download_buffer)
-		{
-			if (context->download_buffer->ptr)
-				pfree(context->download_buffer->ptr);
-			pfree(context->download_buffer);
-		}
-		if (context->upload_buffer)
-		{
-			if (context->upload_buffer->ptr)
-				pfree(context->upload_buffer->ptr);
-			pfree(context->upload_buffer);
-		}
+		/* unlink from linked list first */
+		if (context->prev)
+			context->prev->next = context->next;
+		else
+			open_curl_handles = open_curl_handles->next;
+		if (context->next)
+			context->next->prev = context->prev;
 
 		pfree(context);
 	}
@@ -780,7 +812,7 @@ static size_t
 write_callback(char *buffer, size_t size, size_t nitems, void *userp)
 {
 	churl_context *context = (churl_context *) userp;
-	churl_buffer *context_buffer = context->download_buffer;
+	churl_buffer *context_buffer = &context->download_buffer;
 	const int	nbytes = size * nitems;
 
 	if (!internal_buffer_large_enough(context_buffer, nbytes))
@@ -812,7 +844,7 @@ fill_internal_buffer(churl_context *context, int want)
 
 	/* attempt to fill buffer */
 	while (context->curl_still_running &&
-		   ((context->download_buffer->top - context->download_buffer->bot) < want))
+		   ((context->download_buffer.top - context->download_buffer.bot) < want))
 	{
 		FD_ZERO(&fdread);
 		FD_ZERO(&fdwrite);
@@ -967,10 +999,10 @@ check_response_code(churl_context *context)
 		initStringInfo(&err);
 
 		/* prepare response text if any */
-		if (context->download_buffer->ptr)
+		if (context->download_buffer.ptr)
 		{
-			context->download_buffer->ptr[context->download_buffer->top] = '\0';
-			response_text = context->download_buffer->ptr + context->download_buffer->bot;
+			context->download_buffer.ptr[context->download_buffer.top] = '\0';
+			response_text = context->download_buffer.ptr + context->download_buffer.bot;
 		}
 
 		appendStringInfo(&err, "PXF server error");

--- a/external-table/src/pxfbridge.c
+++ b/external-table/src/pxfbridge.c
@@ -40,7 +40,7 @@ gpbridge_cleanup(gphadoop_context *context)
 	if (context == NULL)
 		return;
 
-	churl_cleanup(context->churl_handle, context->after_error);
+	churl_cleanup(context->churl_handle, false);
 	context->churl_handle = NULL;
 
 	churl_headers_cleanup(context->churl_headers);

--- a/external-table/src/pxfbridge.c
+++ b/external-table/src/pxfbridge.c
@@ -41,10 +41,6 @@ gpbridge_cleanup(gphadoop_context *context)
 		return;
 
 	churl_cleanup(context->churl_handle, false);
-	context->churl_handle = NULL;
-
-	churl_headers_cleanup(context->churl_headers);
-	context->churl_headers = NULL;
 
 	if (context->gphd_uri != NULL)
 	{

--- a/external-table/src/pxfbridge.h
+++ b/external-table/src/pxfbridge.h
@@ -43,7 +43,6 @@ typedef struct
 	ProjectionInfo *proj_info;
 	List           *quals;
 	bool           completed;
-	bool           after_error;
 } gphadoop_context;
 
 /*

--- a/external-table/src/pxfprotocol.c
+++ b/external-table/src/pxfprotocol.c
@@ -26,7 +26,6 @@
 #include "access/fileam.h"
 #endif
 #include "utils/elog.h"
-#include "utils/resowner.h"
 
 /* define magic module unless run as a part of test cases */
 #ifndef UNIT_TESTING
@@ -155,21 +154,6 @@ pxfprotocol_import(PG_FUNCTION_ARGS)
 	PG_RETURN_INT32(bytes_read);
 }
 
-static void
-url_curl_abort_callback(ResourceReleasePhase phase,
-						bool isCommit,
-						bool isTopLevel,
-						void *arg)
-{
-	gphadoop_context *context = arg;
-
-	if (phase != RESOURCE_RELEASE_AFTER_LOCKS || isCommit || !isTopLevel)
-		return;
-
-	context->after_error = true;
-	cleanup_context(context);
-}
-
 /*
  * Allocates context and sets values for the segment
  */
@@ -206,8 +190,6 @@ create_context(PG_FUNCTION_ARGS, bool is_import)
 	context->proj_info = proj_info;
 	context->quals     = filter_quals;
 	context->completed = false;
-	context->after_error = false;
-	RegisterResourceReleaseCallback(url_curl_abort_callback, context);
 	return context;
 }
 
@@ -219,7 +201,6 @@ cleanup_context(gphadoop_context *context)
 {
 	if (context != NULL)
 	{
-		UnregisterResourceReleaseCallback(url_curl_abort_callback, context);
 		gpbridge_cleanup(context);
 		pfree(context->uri.data);
 		pfree(context);

--- a/fdw/pxf_bridge.c
+++ b/fdw/pxf_bridge.c
@@ -43,10 +43,6 @@ PxfBridgeCleanup(PxfFdwModifyState *pxfmstate)
 		return;
 
 	churl_cleanup(pxfmstate->churl_handle, false);
-	pxfmstate->churl_handle = NULL;
-
-	churl_headers_cleanup(pxfmstate->churl_headers);
-	pxfmstate->churl_headers = NULL;
 
 	if (pxfmstate->uri.data)
 	{
@@ -56,6 +52,28 @@ PxfBridgeCleanup(PxfFdwModifyState *pxfmstate)
 	if (pxfmstate->options)
 	{
 		pfree(pxfmstate->options);
+	}
+}
+
+/*
+ * Clean up churl related data structures from the PXF FDW scan state.
+ */
+void
+PxfBridgeScanCleanup(PxfFdwScanState *pxfsstate)
+{
+	if (pxfsstate == NULL)
+		return;
+
+	churl_cleanup(pxfsstate->churl_handle, false);
+
+	if (pxfsstate->uri.data)
+	{
+		pfree(pxfsstate->uri.data);
+	}
+
+	if (pxfsstate->options)
+	{
+		pfree(pxfsstate->options);
 	}
 }
 

--- a/fdw/pxf_bridge.h
+++ b/fdw/pxf_bridge.h
@@ -76,6 +76,7 @@ typedef struct PxfFdwModifyState
 
 /* Clean up churl related data structures from the context */
 void		PxfBridgeCleanup(PxfFdwModifyState *context);
+void		PxfBridgeScanCleanup(PxfFdwScanState *context);
 
 /* Sets up data before starting import */
 void		PxfBridgeImportStart(PxfFdwScanState *pxfsstate);

--- a/fdw/pxf_fdw.c
+++ b/fdw/pxf_fdw.c
@@ -568,6 +568,8 @@ pxfEndForeignScan(ForeignScanState *node)
 	if (pxfsstate)
 		EndCopyFrom(pxfsstate->cstate);
 
+	PxfBridgeScanCleanup(pxfsstate);
+
 	elog(DEBUG5, "pxf_fdw: pxfEndForeignScan ends on segment: %d", PXF_SEGMENT_ID);
 }
 


### PR DESCRIPTION
The [patch](https://github.com/arenadata/pxf/pull/42) does not cover the fdw.
Also, that patch only works on the top-level transaction, while on sub-transactions it would be better not to wait so long.
Also, some resources in that patch are allocated in different contexts, and it may happen that they are freed before or after the callback, which can lead to a segfault.
More criticism of the old patch can be found in the [upstream](https://github.com/greenplum-db/pxf/pull/992).

The C-part of the PXF external table releases the context (`cleanup_context`) only on the last call in the `pxfprotocol_export` and `pxfprotocol_import` functions.
The C-part of the PXF fdw releases the context (`PxfBridgeCleanup`) only in the `FinishForeignModify` function.
That is, on errors, the context is not released, including curl-connections to the Java-part are not closed.
Therefore, I added a callback to release resources on errors, which releases the context, including closing curl-connections.

For example, this may happen when a request is canceled when an exclusive lock has been taken on a table referenced by an external table or fdw.
1) create external table
```sql
CREATE EXTENSION pxf;
CREATE TABLE t(a int) DISTRIBUTED BY (a);
INSERT INTO t SELECT i FROM generate_series(1, 1000) i;
CREATE EXTERNAL TABLE e(a int) LOCATION('pxf://t?PROFILE=JDBC&JDBC_DRIVER=org.postgresql.Driver&DB_URL=jdbc:postgresql://localhost:6432/postgres') FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
```
or create fdw
```sql
CREATE EXTENSION pxf_fdw;
CREATE TABLE t(a int) DISTRIBUTED BY (a);
INSERT INTO t SELECT i FROM generate_series(1, 1000) i;
CREATE SERVER s FOREIGN DATA WRAPPER jdbc_pxf_fdw OPTIONS (jdbc_driver 'org.postgresql.Driver', db_url 'jdbc:postgresql://localhost:6432/postgres');
CREATE USER MAPPING FOR CURRENT_USER SERVER s;
CREATE FOREIGN TABLE e (a int) SERVER s OPTIONS (resource 't');
```
2) in one session, run the command:
```sql
begin;lock table t in ACCESS exclusive mode;
```
and don't close the session.

3) in another session, run the command:
```sql
SELECT count(*) FROM e;
```
and then interrupt its execution with Ctrl+C, but don't close the session.
The connection from the C-part to the Java-part remains:
```sh
bash-4.2$ netstat -enpt | grep :5888
tcp        0      0 127.0.0.1:42236         127.0.0.1:5888          ESTABLISHED 1000       7244695    161781/postgres:  6 
tcp        0      0 127.0.0.1:5888          127.0.0.1:42236         ESTABLISHED 1000       7229437    157250/java         
```
expected (and with patch): adb connection is closed, but Java-part remain:
```sh
bash-4.2$ netstat -enpt | grep :5888
tcp        1      0 127.0.0.1:5888          127.0.0.1:47074         CLOSE_WAIT  1000       6885317    144206/java         
```
Another example with subtransaction
1) create external table
```sql
CREATE EXTENSION pxf;
CREATE TABLE t(a int) DISTRIBUTED BY (a);
INSERT INTO t SELECT i FROM generate_series(1, 1000) i;
CREATE EXTERNAL TABLE e(a int, b int) LOCATION('pxf://t?PROFILE=JDBC&JDBC_DRIVER=org.postgresql.Driver&DB_URL=jdbc:postgresql://localhost:6432/postgres') FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
```
or create fdw
```sql
CREATE EXTENSION pxf_fdw;
CREATE TABLE t(a int) DISTRIBUTED BY (a);
INSERT INTO t SELECT i FROM generate_series(1, 1000) i;
CREATE SERVER s FOREIGN DATA WRAPPER jdbc_pxf_fdw OPTIONS (jdbc_driver 'org.postgresql.Driver', db_url 'jdbc:postgresql://localhost:6432/postgres');
CREATE USER MAPPING FOR CURRENT_USER SERVER s;
CREATE FOREIGN TABLE e (a int, b int) SERVER s OPTIONS (resource 't');
```
2) run commands:
```sql
BEGIN;
INSERT INTO t SELECT i FROM generate_series(1, 1000) i;
SAVEPOINT a;
SELECT count(*) FROM e;
```
and don't close the session.
The connection from the C-part to the Java-part remains:
```sh
bash-4.2$ netstat -enpt | grep :5888
tcp        6      0 127.0.0.1:35230         127.0.0.1:5888          CLOSE_WAIT  1000       2135014    36419/postgres:  64 
```
expected (and with patch): adb connection is closed.