### PR TITLE
ADBDEV-4253: Cancel read requests in PXF service

### DIFF
--- a/external-table/src/libchurl.c
+++ b/external-table/src/libchurl.c
@@ -424,8 +424,8 @@ churl_init_download(const char *url, CHURL_HEADERS headers)
 	return (CHURL_HANDLE) context;
 }
 
-void
-churl_set_local_port_to_headers(CHURL_HANDLE handle, CHURL_HEADERS headers)
+long
+churl_get_local_port(CHURL_HANDLE handle)
 {
 	churl_context *context = (churl_context *) handle;
 
@@ -436,7 +436,7 @@ churl_set_local_port_to_headers(CHURL_HANDLE handle, CHURL_HEADERS headers)
 		elog(ERROR, "internal error: curl_easy_getinfo failed(%d - %s)",
 			curl_error, curl_easy_strerror(curl_error));
 
-	churl_headers_override(headers, "X-GP-CLIENT-PORT", psprintf("%li", local_port));
+	return local_port;
 }
 
 void

--- a/external-table/src/libchurl.c
+++ b/external-table/src/libchurl.c
@@ -389,6 +389,12 @@ churl_init(const char *url, CHURL_HEADERS headers)
 }
 
 CHURL_HANDLE
+churl_init_upload(const char *url, CHURL_HEADERS headers)
+{
+	return churl_init_upload_timeout(url, headers, 0);
+}
+
+CHURL_HANDLE
 churl_init_upload_timeout(const char *url, CHURL_HEADERS headers, long timeout)
 {
 	churl_context *context = churl_init(url, headers);
@@ -405,12 +411,6 @@ churl_init_upload_timeout(const char *url, CHURL_HEADERS headers, long timeout)
 
 	setup_multi_handle(context);
 	return (CHURL_HANDLE) context;
-}
-
-CHURL_HANDLE
-churl_init_upload(const char *url, CHURL_HEADERS headers)
-{
-	return churl_init_upload_timeout(url, headers, 0);
 }
 
 CHURL_HANDLE

--- a/external-table/src/libchurl.c
+++ b/external-table/src/libchurl.c
@@ -203,7 +203,7 @@ churl_headers_override(CHURL_HEADERS headers, const char *key, const char *value
 	Assert(key != NULL);
 
 	/* key to compare with in the headers */
-	key_option = build_header_str("%s: %s", key, value ? "" : NULL);
+	key_option = build_header_str("%s:%s", key, value ? "" : NULL);
 
 	/* find key in headers list */
 	while (header_cell != NULL)
@@ -251,7 +251,7 @@ churl_headers_remove(CHURL_HEADERS headers, const char *key, bool has_value)
 	Assert(key != NULL);
 
 	/* key to compare with in the headers */
-	key_option = build_header_str("%s: %s", key, has_value ? "" : NULL);
+	key_option = build_header_str("%s:%s", key, has_value ? "" : NULL);
 
 	/* find key in headers list */
 	while (to_del_cell != NULL)

--- a/external-table/src/libchurl.c
+++ b/external-table/src/libchurl.c
@@ -430,7 +430,7 @@ churl_get_local_port(CHURL_HANDLE handle)
 	churl_context *context = (churl_context *) handle;
 
 	int curl_error;
-	long local_port = -1L;
+	long local_port = 0;
 
 	if (CURLE_OK != (curl_error = curl_easy_getinfo(context->curl_handle, CURLINFO_LOCAL_PORT, &local_port)))
 		elog(WARNING, "internal error: curl_easy_getinfo failed(%d - %s)",

--- a/external-table/src/libchurl.c
+++ b/external-table/src/libchurl.c
@@ -178,40 +178,6 @@ build_header_str(const char *format, const char *key, const char *value)
 	return header_option;
 }
 
-const char *
-churl_headers_value(CHURL_HEADERS headers, const char *key)
-{
-	churl_settings *settings = (churl_settings *) headers;
-	struct curl_slist *header_cell = settings->headers;
-	char	   *key_option = NULL;
-	char	   *header_data = NULL;
-	int			key_option_len;
-
-	/* key must not be empty */
-	Assert(key != NULL);
-
-	/* key to compare with in the headers */
-	key_option = build_header_str("%s: %s", key, "");
-	key_option_len = strlen(key_option);
-
-	/* find key in headers list */
-	while (header_cell != NULL)
-	{
-		header_data = header_cell->data;
-
-		if (strncmp(key_option, header_data, key_option_len) == 0)
-		{
-			elog(DEBUG2, "churl_headers_value: Found existing header %s with key %s",
-				 header_data, key_option);
-			return header_data + strlen(key) + 2;
-		}
-
-		header_cell = header_cell->next;
-	}
-
-	elog(ERROR, "churl_headers_value error: %s not found in headers", key);
-}
-
 void
 churl_headers_append(CHURL_HEADERS headers, const char *key, const char *value)
 {

--- a/external-table/src/libchurl.c
+++ b/external-table/src/libchurl.c
@@ -178,6 +178,40 @@ build_header_str(const char *format, const char *key, const char *value)
 	return header_option;
 }
 
+const char *
+churl_headers_value(CHURL_HEADERS headers, const char *key)
+{
+	churl_settings *settings = (churl_settings *) headers;
+	struct curl_slist *header_cell = settings->headers;
+	char	   *key_option = NULL;
+	char	   *header_data = NULL;
+	int			key_option_len;
+
+	/* key must not be empty */
+	Assert(key != NULL);
+
+	/* key to compare with in the headers */
+	key_option = build_header_str("%s: %s", key, "");
+	key_option_len = strlen(key_option);
+
+	/* find key in headers list */
+	while (header_cell != NULL)
+	{
+		header_data = header_cell->data;
+
+		if (strncmp(key_option, header_data, key_option_len) == 0)
+		{
+			elog(DEBUG2, "churl_headers_value: Found existing header %s with key %s",
+				 header_data, key_option);
+			return header_data + strlen(key) + 2;
+		}
+
+		header_cell = header_cell->next;
+	}
+
+	elog(ERROR, "churl_headers_value error: %s not found in headers", key);
+}
+
 void
 churl_headers_append(CHURL_HEADERS headers, const char *key, const char *value)
 {
@@ -203,7 +237,7 @@ churl_headers_override(CHURL_HEADERS headers, const char *key, const char *value
 	Assert(key != NULL);
 
 	/* key to compare with in the headers */
-	key_option = build_header_str("%s:%s", key, value ? "" : NULL);
+	key_option = build_header_str("%s: %s", key, value ? "" : NULL);
 
 	/* find key in headers list */
 	while (header_cell != NULL)
@@ -251,7 +285,7 @@ churl_headers_remove(CHURL_HEADERS headers, const char *key, bool has_value)
 	Assert(key != NULL);
 
 	/* key to compare with in the headers */
-	key_option = build_header_str("%s:%s", key, has_value ? "" : NULL);
+	key_option = build_header_str("%s: %s", key, has_value ? "" : NULL);
 
 	/* find key in headers list */
 	while (to_del_cell != NULL)
@@ -389,7 +423,7 @@ churl_init(const char *url, CHURL_HEADERS headers)
 }
 
 CHURL_HANDLE
-churl_init_upload(const char *url, CHURL_HEADERS headers)
+churl_init_upload_timeout(const char *url, CHURL_HEADERS headers, long timeout)
 {
 	churl_context *context = churl_init(url, headers);
 
@@ -398,12 +432,19 @@ churl_init_upload(const char *url, CHURL_HEADERS headers)
 	set_curl_option(context, CURLOPT_POST, (const void *) true);
 	set_curl_option(context, CURLOPT_READFUNCTION, read_callback);
 	set_curl_option(context, CURLOPT_READDATA, context);
+	set_curl_option(context, CURLOPT_TIMEOUT, (const void *) timeout);
 	churl_headers_append(headers, "Content-Type", "application/octet-stream");
 	churl_headers_append(headers, "Transfer-Encoding", "chunked");
 	churl_headers_append(headers, "Expect", "100-continue");
 
 	setup_multi_handle(context);
 	return (CHURL_HANDLE) context;
+}
+
+CHURL_HANDLE
+churl_init_upload(const char *url, CHURL_HEADERS headers)
+{
+	return churl_init_upload_timeout(url, headers, 0);
 }
 
 CHURL_HANDLE
@@ -415,6 +456,21 @@ churl_init_download(const char *url, CHURL_HEADERS headers)
 
 	setup_multi_handle(context);
 	return (CHURL_HANDLE) context;
+}
+
+void
+churl_set_local_port_to_headers(CHURL_HANDLE handle, CHURL_HEADERS headers)
+{
+	churl_context *context = (churl_context *) handle;
+
+	int curl_error;
+	long local_port;
+
+	if (CURLE_OK != (curl_error = curl_easy_getinfo(context->curl_handle, CURLINFO_LOCAL_PORT, &local_port)))
+		elog(ERROR, "internal error: curl_easy_getinfo failed(%d - %s)",
+			curl_error, curl_easy_strerror(curl_error));
+
+	churl_headers_override(headers, "X-GP-CLIENT-PORT", psprintf("%li", local_port));
 }
 
 void

--- a/external-table/src/libchurl.c
+++ b/external-table/src/libchurl.c
@@ -424,16 +424,16 @@ churl_init_download(const char *url, CHURL_HEADERS headers)
 	return (CHURL_HANDLE) context;
 }
 
-long
+int
 churl_get_local_port(CHURL_HANDLE handle)
 {
 	churl_context *context = (churl_context *) handle;
 
 	int curl_error;
-	long local_port;
+	long local_port = -1L;
 
 	if (CURLE_OK != (curl_error = curl_easy_getinfo(context->curl_handle, CURLINFO_LOCAL_PORT, &local_port)))
-		elog(ERROR, "internal error: curl_easy_getinfo failed(%d - %s)",
+		elog(WARNING, "internal error: curl_easy_getinfo failed(%d - %s)",
 			curl_error, curl_easy_strerror(curl_error));
 
 	return local_port;

--- a/external-table/src/libchurl.c
+++ b/external-table/src/libchurl.c
@@ -428,7 +428,6 @@ int
 churl_get_local_port(CHURL_HANDLE handle)
 {
 	churl_context *context = (churl_context *) handle;
-
 	int curl_error;
 	long local_port = 0;
 

--- a/external-table/src/libchurl.h
+++ b/external-table/src/libchurl.h
@@ -105,6 +105,10 @@ void		churl_headers_cleanup(CHURL_HEADERS headers);
  * returns a handle to churl transfer
  */
 CHURL_HANDLE churl_init_upload(const char *url, CHURL_HEADERS headers);
+CHURL_HANDLE churl_init_upload_timeout(const char *url, CHURL_HEADERS headers, long timeout);
+
+void		churl_set_local_port_to_headers(CHURL_HANDLE handle, CHURL_HEADERS headers);
+const char *churl_headers_value(CHURL_HEADERS headers, const char *key);
 
 /*
  * Start a download to url

--- a/external-table/src/libchurl.h
+++ b/external-table/src/libchurl.h
@@ -108,7 +108,6 @@ CHURL_HANDLE churl_init_upload(const char *url, CHURL_HEADERS headers);
 CHURL_HANDLE churl_init_upload_timeout(const char *url, CHURL_HEADERS headers, long timeout);
 
 void		churl_set_local_port_to_headers(CHURL_HANDLE handle, CHURL_HEADERS headers);
-const char *churl_headers_value(CHURL_HEADERS headers, const char *key);
 
 /*
  * Start a download to url

--- a/external-table/src/libchurl.h
+++ b/external-table/src/libchurl.h
@@ -107,7 +107,7 @@ void		churl_headers_cleanup(CHURL_HEADERS headers);
 CHURL_HANDLE churl_init_upload(const char *url, CHURL_HEADERS headers);
 CHURL_HANDLE churl_init_upload_timeout(const char *url, CHURL_HEADERS headers, long timeout);
 
-void		churl_set_local_port_to_headers(CHURL_HANDLE handle, CHURL_HEADERS headers);
+long		churl_get_local_port(CHURL_HANDLE handle);
 
 /*
  * Start a download to url

--- a/external-table/src/libchurl.h
+++ b/external-table/src/libchurl.h
@@ -107,6 +107,9 @@ void		churl_headers_cleanup(CHURL_HEADERS headers);
 CHURL_HANDLE churl_init_upload(const char *url, CHURL_HEADERS headers);
 CHURL_HANDLE churl_init_upload_timeout(const char *url, CHURL_HEADERS headers, long timeout);
 
+/*
+ * Returns local port of connected handle or 0
+ */
 long		churl_get_local_port(CHURL_HANDLE handle);
 
 /*

--- a/external-table/src/libchurl.h
+++ b/external-table/src/libchurl.h
@@ -110,7 +110,7 @@ CHURL_HANDLE churl_init_upload_timeout(const char *url, CHURL_HEADERS headers, l
 /*
  * Returns local port of connected handle or 0
  */
-long		churl_get_local_port(CHURL_HANDLE handle);
+int			churl_get_local_port(CHURL_HANDLE handle);
 
 /*
  * Start a download to url

--- a/external-table/src/pxfbridge.c
+++ b/external-table/src/pxfbridge.c
@@ -41,6 +41,10 @@ gpbridge_cleanup(gphadoop_context *context)
 		return;
 
 	churl_cleanup(context->churl_handle, false);
+	context->churl_handle = NULL;
+
+	churl_headers_cleanup(context->churl_headers);
+	context->churl_headers = NULL;
 
 	if (context->gphd_uri != NULL)
 	{

--- a/external-table/src/pxfbridge.c
+++ b/external-table/src/pxfbridge.c
@@ -78,6 +78,7 @@ gpbridge_cancel(pxfbridge_cancel *cancel)
 
 		churl_headers_append(cancel->churl_headers, "X-GP-CLIENT-PORT", psprintf("%i", local_port));
 
+		initStringInfo(&cancel->uri);
 		build_uri_for_cancel(cancel);
 		churl_handle = churl_init_upload_timeout(cancel->uri.data, cancel->churl_headers, 1L);
 
@@ -161,9 +162,8 @@ gpbridge_import_start(gphadoop_context *context)
 
 	oldcontext = MemoryContextSwitchTo(CurTransactionContext);
 	cancel = palloc0(sizeof(pxfbridge_cancel));
-	context->cancel = cancel;
-	initStringInfo(&cancel->uri);
 	MemoryContextSwitchTo(oldcontext);
+	context->cancel = cancel;
 	cancel->churl_headers = context->churl_headers;
 	cancel->churl_handle = context->churl_handle;
 	cancel->owner = CurTransactionResourceOwner;

--- a/external-table/src/pxfbridge.c
+++ b/external-table/src/pxfbridge.c
@@ -70,16 +70,16 @@ gpbridge_cancel(pxfbridge_cancel *cancel)
 	if (!IsAbortInProgress())
 		return;
 
-	long local_port = churl_get_local_port(cancel->churl_handle);
+	int local_port = churl_get_local_port(cancel->churl_handle);
 
-	if (local_port == 0)
+	if (local_port <= 0)
 		return;
 
 	int savedInterruptHoldoffCount = InterruptHoldoffCount;
 
 	PG_TRY();
 	{
-		churl_headers_append(cancel->churl_headers, "X-GP-CLIENT-PORT", psprintf("%li", local_port));
+		churl_headers_append(cancel->churl_headers, "X-GP-CLIENT-PORT", psprintf("%i", local_port));
 
 		char *uri = build_uri_for_cancel(cancel);
 

--- a/external-table/src/pxfbridge.c
+++ b/external-table/src/pxfbridge.c
@@ -138,14 +138,12 @@ gpbridge_import_start(gphadoop_context *context)
 	pxfbridge_cancel *cancel;
 
 	build_uri_for_read(context);
-	oldcontext = MemoryContextSwitchTo(CurTransactionContext);
 	context->churl_headers = churl_headers_init();
-	MemoryContextSwitchTo(oldcontext);
 	add_querydata_to_http_headers(context);
 
-	oldcontext = MemoryContextSwitchTo(CurTransactionContext);
 	context->churl_handle = churl_init_download(context->uri.data, context->churl_headers);
 
+	oldcontext = MemoryContextSwitchTo(CurTransactionContext);
 	cancel = palloc0(sizeof(pxfbridge_cancel));
 	initStringInfo(&cancel->uri);
 	MemoryContextSwitchTo(oldcontext);

--- a/external-table/src/pxfbridge.c
+++ b/external-table/src/pxfbridge.c
@@ -34,7 +34,6 @@ typedef struct
 	ResourceOwner  owner;
 } pxfbridge_cancel;
 
-
 /* helper function declarations */
 static void gpbridge_cancel(pxfbridge_cancel *cancel);
 static char *build_uri_for_cancel(pxfbridge_cancel *cancel);

--- a/external-table/src/pxfbridge.c
+++ b/external-table/src/pxfbridge.c
@@ -60,25 +60,30 @@ gpbridge_abort_callback(ResourceReleasePhase phase,
 static void
 gpbridge_cancel(pxfbridge_cancel *cancel)
 {
+	int local_port;
+	int savedInterruptHoldoffCount;
+
 	UnregisterResourceReleaseCallback(gpbridge_abort_callback, cancel);
 
 	if (!IsAbortInProgress())
 		return;
 
-	int local_port = churl_get_local_port(cancel->churl_handle);
+	local_port = churl_get_local_port(cancel->churl_handle);
 
 	if (local_port == 0)
 		return;
 
-	int savedInterruptHoldoffCount = InterruptHoldoffCount;
+	savedInterruptHoldoffCount = InterruptHoldoffCount;
 
 	PG_TRY();
 	{
+		char *uri;
+		CHURL_HANDLE churl_handle;
+
 		churl_headers_append(cancel->churl_headers, "X-GP-CLIENT-PORT", psprintf("%i", local_port));
 
-		char *uri = build_uri_for_cancel(cancel);
-
-		CHURL_HANDLE churl_handle = churl_init_upload_timeout(uri, cancel->churl_headers, 1L);
+		uri = build_uri_for_cancel(cancel);
+		churl_handle = churl_init_upload_timeout(uri, cancel->churl_headers, 1L);
 
 		churl_cleanup(churl_handle, false);
 	}

--- a/external-table/src/pxfbridge.c
+++ b/external-table/src/pxfbridge.c
@@ -143,7 +143,7 @@ gpbridge_import_start(gphadoop_context *context)
 	MemoryContextSwitchTo(oldcontext);
 	cancel->churl_headers = context->churl_headers;
 	cancel->churl_handle = context->churl_handle;
-	cancel->owner = CurrentResourceOwner;
+	cancel->owner = CurTransactionResourceOwner;
 	RegisterResourceReleaseCallback(gpbridge_abort_callback, cancel);
 
 	/* read some bytes to make sure the connection is established */

--- a/external-table/src/pxfbridge.c
+++ b/external-table/src/pxfbridge.c
@@ -76,7 +76,7 @@ gpbridge_cleanup(gphadoop_context *context)
 		{
 			PG_TRY();
 			{
-				churl_headers_override(context->churl_headers, "X-GP-CLIENT-PORT", psprintf("%li", local_port));
+				churl_headers_append(context->churl_headers, "X-GP-CLIENT-PORT", psprintf("%li", local_port));
 
 				build_uri_for_cancel(context);
 

--- a/external-table/src/pxfbridge.c
+++ b/external-table/src/pxfbridge.c
@@ -36,7 +36,6 @@ typedef struct
 } pxfbridge_cancel;
 
 /* helper function declarations */
-static void gpbridge_cancel(pxfbridge_cancel *cancel);
 static void gpbridge_cancel_cleanup(pxfbridge_cancel *cancel);
 static void build_uri_for_cancel(pxfbridge_cancel *cancel);
 static void build_uri_for_read(gphadoop_context *context);

--- a/external-table/src/pxfbridge.c
+++ b/external-table/src/pxfbridge.c
@@ -54,7 +54,8 @@ gpbridge_abort_callback(ResourceReleasePhase phase,
 	}
 }
 
-static void gpbridge_cancel(gphadoop_context *context)
+static void
+gpbridge_cancel(gphadoop_context *context)
 {
 	UnregisterResourceReleaseCallback(gpbridge_abort_callback, context);
 

--- a/external-table/src/pxfbridge.c
+++ b/external-table/src/pxfbridge.c
@@ -24,12 +24,34 @@
 #include "cdb/cdbtm.h"
 #include "cdb/cdbvars.h"
 #include "utils/guc.h"
+#include "access/xact.h"
 
 /* helper function declarations */
+static void build_uri_for_cancel(gphadoop_context *context);
 static void build_uri_for_read(gphadoop_context *context);
 static void build_uri_for_write(gphadoop_context *context);
 static void add_querydata_to_http_headers(gphadoop_context *context);
 static size_t fill_buffer(gphadoop_context *context, char *start, size_t size);
+
+static void
+gpbridge_import_abort_callback(ResourceReleasePhase phase,
+						bool isCommit,
+						bool isTopLevel,
+						void *arg)
+{
+	gphadoop_context *context = arg;
+
+	if (phase != RESOURCE_RELEASE_AFTER_LOCKS)
+		return;
+
+	if (context->owner == CurrentResourceOwner)
+	{
+		if (isCommit)
+			elog(LOG, "pxf gpbridge_import reference leak: %p still referenced", arg);
+
+		gpbridge_cleanup(context);
+	}
+}
 
 /*
  * Clean up churl related data structures from the context.
@@ -40,8 +62,41 @@ gpbridge_cleanup(gphadoop_context *context)
 	if (context == NULL)
 		return;
 
-	churl_cleanup(context->churl_handle, false);
-	context->churl_handle = NULL;
+	UnregisterResourceReleaseCallback(gpbridge_import_abort_callback, context);
+
+	if (!context->upload && IsAbortInProgress())
+	{
+		int savedInterruptHoldoffCount;
+
+		PG_TRY();
+		{
+			savedInterruptHoldoffCount = InterruptHoldoffCount;
+
+			churl_set_local_port_to_headers(context->churl_handle, context->churl_headers);
+
+			churl_cleanup(context->churl_handle, true);
+			context->churl_handle = NULL;
+
+			build_uri_for_cancel(context);
+
+			CHURL_HANDLE churl_handle = churl_init_upload_timeout(context->uri.data, context->churl_headers, 1L);
+
+			churl_cleanup(churl_handle, false);
+		}
+		PG_CATCH();
+		{
+			InterruptHoldoffCount = savedInterruptHoldoffCount;
+
+			if (!elog_dismiss(WARNING))
+				elog(WARNING, "unable to dismiss error");
+		}
+		PG_END_TRY();
+	}
+	else
+	{
+		churl_cleanup(context->churl_handle, false);
+		context->churl_handle = NULL;
+	}
 
 	churl_headers_cleanup(context->churl_headers);
 	context->churl_headers = NULL;
@@ -65,11 +120,15 @@ gpbridge_cleanup(gphadoop_context *context)
 void
 gpbridge_import_start(gphadoop_context *context)
 {
+	context->upload = false;
 	build_uri_for_read(context);
 	context->churl_headers = churl_headers_init();
 	add_querydata_to_http_headers(context);
 
 	context->churl_handle = churl_init_download(context->uri.data, context->churl_headers);
+	context->owner = CurrentResourceOwner;
+
+	RegisterResourceReleaseCallback(gpbridge_import_abort_callback, context);
 
 	/* read some bytes to make sure the connection is established */
 	churl_read_check_connectivity(context->churl_handle);
@@ -81,6 +140,7 @@ gpbridge_import_start(gphadoop_context *context)
 void
 gpbridge_export_start(gphadoop_context *context)
 {
+	context->upload = true;
 	elog(DEBUG2, "pxf: file name for write: %s", context->gphd_uri->data);
 	build_uri_for_write(context);
 	context->churl_headers = churl_headers_init();
@@ -126,6 +186,27 @@ gpbridge_write(gphadoop_context *context, char *databuf, int datalen)
 	}
 
 	return (int) n;
+}
+
+/*
+ * Format the URI for cancel by adding PXF service endpoint details
+ */
+static void
+build_uri_for_cancel(gphadoop_context *context)
+{
+	const char *host = churl_headers_value(context->churl_headers, "X-GP-URL-HOST");
+	const char *port = churl_headers_value(context->churl_headers, "X-GP-URL-PORT");
+
+	resetStringInfo(&context->uri);
+	appendStringInfo(&context->uri, "http://%s:%s/%s/cancel",
+					 host, port, PXF_SERVICE_PREFIX);
+
+	if ((LOG >= log_min_messages) || (LOG >= client_min_messages))
+	{
+		appendStringInfo(&context->uri, "?trace=true");
+	}
+
+	elog(DEBUG2, "pxf: uri %s for cancel", context->uri.data);
 }
 
 /*

--- a/external-table/src/pxfbridge.c
+++ b/external-table/src/pxfbridge.c
@@ -88,7 +88,10 @@ gpbridge_cleanup(gphadoop_context *context)
 			InterruptHoldoffCount = savedInterruptHoldoffCount;
 
 			if (!elog_dismiss(WARNING))
+			{
+				FlushErrorState();
 				elog(WARNING, "unable to dismiss error");
+			}
 		}
 		PG_END_TRY();
 	}

--- a/external-table/src/pxfbridge.c
+++ b/external-table/src/pxfbridge.c
@@ -195,12 +195,9 @@ gpbridge_write(gphadoop_context *context, char *databuf, int datalen)
 static void
 build_uri_for_cancel(gphadoop_context *context)
 {
-	const char *host = churl_headers_value(context->churl_headers, "X-GP-URL-HOST");
-	const char *port = churl_headers_value(context->churl_headers, "X-GP-URL-PORT");
-
 	resetStringInfo(&context->uri);
-	appendStringInfo(&context->uri, "http://%s:%s/%s/cancel",
-					 host, port, PXF_SERVICE_PREFIX);
+	appendStringInfo(&context->uri, "http://%s/%s/cancel",
+					 get_authority(), PXF_SERVICE_PREFIX);
 
 	if ((LOG >= log_min_messages) || (LOG >= client_min_messages))
 	{

--- a/external-table/src/pxfbridge.c
+++ b/external-table/src/pxfbridge.c
@@ -25,6 +25,7 @@
 #include "cdb/cdbvars.h"
 #include "utils/guc.h"
 #include "access/xact.h"
+#include "utils/memutils.h"
 
 typedef struct
 {
@@ -135,12 +136,16 @@ void
 gpbridge_import_start(gphadoop_context *context)
 {
 	build_uri_for_read(context);
+	MemoryContext oldcontext = MemoryContextSwitchTo(CurTransactionContext);
 	context->churl_headers = churl_headers_init();
+	MemoryContextSwitchTo(oldcontext);
 	add_querydata_to_http_headers(context);
 
+	oldcontext = MemoryContextSwitchTo(CurTransactionContext);
 	context->churl_handle = churl_init_download(context->uri.data, context->churl_headers);
 
 	pxfbridge_cancel *cancel = palloc0(sizeof(pxfbridge_cancel));
+	MemoryContextSwitchTo(oldcontext);
 	cancel->churl_headers = context->churl_headers;
 	cancel->churl_handle = context->churl_handle;
 	cancel->owner = CurrentResourceOwner;

--- a/external-table/src/pxfbridge.c
+++ b/external-table/src/pxfbridge.c
@@ -55,12 +55,7 @@ gpbridge_abort_callback(ResourceReleasePhase phase,
 		return;
 
 	if (cancel->owner == CurrentResourceOwner)
-	{
-		if (isCommit)
-			elog(LOG, "pxf gpbridge_import reference leak: %p still referenced", arg);
-
 		gpbridge_cancel(cancel);
-	}
 }
 
 static void

--- a/external-table/src/pxfbridge.c
+++ b/external-table/src/pxfbridge.c
@@ -70,7 +70,8 @@ gpbridge_cleanup(gphadoop_context *context)
 
 		PG_TRY();
 		{
-			churl_set_local_port_to_headers(context->churl_handle, context->churl_headers);
+			long local_port = churl_get_local_port(context->churl_handle);
+			churl_headers_override(context->churl_headers, "X-GP-CLIENT-PORT", psprintf("%li", local_port));
 
 			churl_cleanup(context->churl_handle, true);
 			context->churl_handle = NULL;

--- a/external-table/src/pxfbridge.c
+++ b/external-table/src/pxfbridge.c
@@ -134,8 +134,11 @@ gpbridge_cleanup(gphadoop_context *context)
 void
 gpbridge_import_start(gphadoop_context *context)
 {
+	MemoryContext oldcontext;
+	pxfbridge_cancel *cancel;
+
 	build_uri_for_read(context);
-	MemoryContext oldcontext = MemoryContextSwitchTo(CurTransactionContext);
+	oldcontext = MemoryContextSwitchTo(CurTransactionContext);
 	context->churl_headers = churl_headers_init();
 	MemoryContextSwitchTo(oldcontext);
 	add_querydata_to_http_headers(context);
@@ -143,7 +146,7 @@ gpbridge_import_start(gphadoop_context *context)
 	oldcontext = MemoryContextSwitchTo(CurTransactionContext);
 	context->churl_handle = churl_init_download(context->uri.data, context->churl_headers);
 
-	pxfbridge_cancel *cancel = palloc0(sizeof(pxfbridge_cancel));
+	cancel = palloc0(sizeof(pxfbridge_cancel));
 	MemoryContextSwitchTo(oldcontext);
 	cancel->churl_headers = context->churl_headers;
 	cancel->churl_handle = context->churl_handle;

--- a/external-table/src/pxfbridge.c
+++ b/external-table/src/pxfbridge.c
@@ -99,7 +99,7 @@ gpbridge_cleanup(gphadoop_context *context)
 
 	UnregisterResourceReleaseCallback(gpbridge_abort_callback, context);
 
-	churl_cleanup(context->churl_handle, IsAbortInProgress());
+	churl_cleanup(context->churl_handle, false);
 	context->churl_handle = NULL;
 
 	churl_headers_cleanup(context->churl_headers);

--- a/external-table/src/pxfbridge.c
+++ b/external-table/src/pxfbridge.c
@@ -108,9 +108,6 @@ gpbridge_cancel_cleanup(pxfbridge_cancel *cancel)
 	if (IsAbortInProgress())
 		gpbridge_cancel(cancel);
 
-	if (cancel->uri.data)
-		pfree(cancel->uri.data);
-
 	pfree(cancel);
 }
 

--- a/external-table/src/pxfbridge.c
+++ b/external-table/src/pxfbridge.c
@@ -134,14 +134,16 @@ gpbridge_cleanup(gphadoop_context *context)
 void
 gpbridge_import_start(gphadoop_context *context)
 {
-	pxfbridge_cancel *cancel = palloc0(sizeof(pxfbridge_cancel));
 	build_uri_for_read(context);
-	cancel->churl_headers = context->churl_headers = churl_headers_init();
+	context->churl_headers = churl_headers_init();
 	add_querydata_to_http_headers(context);
 
-	cancel->churl_handle = context->churl_handle = churl_init_download(context->uri.data, context->churl_headers);
-	cancel->owner = CurrentResourceOwner;
+	context->churl_handle = churl_init_download(context->uri.data, context->churl_headers);
 
+	pxfbridge_cancel *cancel = palloc0(sizeof(pxfbridge_cancel));
+	cancel->churl_headers = context->churl_headers;
+	cancel->churl_handle = context->churl_handle;
+	cancel->owner = CurrentResourceOwner;
 	RegisterResourceReleaseCallback(gpbridge_abort_callback, cancel);
 
 	/* read some bytes to make sure the connection is established */

--- a/external-table/src/pxfbridge.c
+++ b/external-table/src/pxfbridge.c
@@ -66,12 +66,10 @@ gpbridge_cleanup(gphadoop_context *context)
 
 	if (!context->upload && IsAbortInProgress())
 	{
-		int savedInterruptHoldoffCount;
+		int savedInterruptHoldoffCount = InterruptHoldoffCount;
 
 		PG_TRY();
 		{
-			savedInterruptHoldoffCount = InterruptHoldoffCount;
-
 			churl_set_local_port_to_headers(context->churl_handle, context->churl_headers);
 
 			churl_cleanup(context->churl_handle, true);

--- a/external-table/src/pxfbridge.c
+++ b/external-table/src/pxfbridge.c
@@ -67,7 +67,7 @@ gpbridge_cancel(pxfbridge_cancel *cancel)
 
 	int local_port = churl_get_local_port(cancel->churl_handle);
 
-	if (local_port <= 0)
+	if (local_port == 0)
 		return;
 
 	int savedInterruptHoldoffCount = InterruptHoldoffCount;

--- a/external-table/src/pxfbridge.h
+++ b/external-table/src/pxfbridge.h
@@ -43,6 +43,7 @@ typedef struct
 	ProjectionInfo *proj_info;
 	List           *quals;
 	bool           completed;
+	void           *cancel;
 } gphadoop_context;
 
 /*

--- a/external-table/src/pxfbridge.h
+++ b/external-table/src/pxfbridge.h
@@ -44,6 +44,7 @@ typedef struct
 	List           *quals;
 	bool           completed;
 	bool           upload;
+	bool           cancel_request;
 	ResourceOwner  owner;
 } gphadoop_context;
 

--- a/external-table/src/pxfbridge.h
+++ b/external-table/src/pxfbridge.h
@@ -43,7 +43,6 @@ typedef struct
 	ProjectionInfo *proj_info;
 	List           *quals;
 	bool           completed;
-	bool           upload;
 	ResourceOwner  owner;
 } gphadoop_context;
 

--- a/external-table/src/pxfbridge.h
+++ b/external-table/src/pxfbridge.h
@@ -43,7 +43,6 @@ typedef struct
 	ProjectionInfo *proj_info;
 	List           *quals;
 	bool           completed;
-	ResourceOwner  owner;
 } gphadoop_context;
 
 /*

--- a/external-table/src/pxfbridge.h
+++ b/external-table/src/pxfbridge.h
@@ -44,7 +44,6 @@ typedef struct
 	List           *quals;
 	bool           completed;
 	bool           upload;
-	bool           cancel_request;
 	ResourceOwner  owner;
 } gphadoop_context;
 

--- a/external-table/src/pxfbridge.h
+++ b/external-table/src/pxfbridge.h
@@ -43,6 +43,8 @@ typedef struct
 	ProjectionInfo *proj_info;
 	List           *quals;
 	bool           completed;
+	bool           upload;
+	ResourceOwner  owner;
 } gphadoop_context;
 
 /*

--- a/external-table/src/pxfprotocol.c
+++ b/external-table/src/pxfprotocol.c
@@ -190,6 +190,7 @@ create_context(PG_FUNCTION_ARGS, bool is_import)
 	context->proj_info = proj_info;
 	context->quals     = filter_quals;
 	context->completed = false;
+	context->cancel    = NULL;
 	return context;
 }
 

--- a/fdw/libchurl.c
+++ b/fdw/libchurl.c
@@ -29,7 +29,6 @@
 #include "utils/fmgroids.h"
 #include "utils/guc.h"
 #include "utils/jsonapi.h"
-#include "utils/resowner.h"
 
 /* include libcurl without typecheck.
  * This allows wrapping curl_easy_setopt to be wrapped
@@ -53,17 +52,9 @@ typedef struct churl_buffer
 } churl_buffer;
 
 /*
- * holds http header properties
- */
-typedef struct
-{
-	struct curl_slist *headers;
-} churl_settings;
-
-/*
  * internal context of libchurl
  */
-typedef struct churl_context
+typedef struct churl_handle
 {
 	/* curl easy API handle */
 	CURL	   *curl_handle;
@@ -72,8 +63,6 @@ typedef struct churl_context
 	 * curl multi API handle used to allow non-blocking callbacks
 	 */
 	CURLM	   *multi_handle;
-
-	churl_settings churl_headers;
 
 	/*
 	 * curl API puts internal errors in this buffer used for error reporting
@@ -87,10 +76,10 @@ typedef struct churl_context
 	int			curl_still_running;
 
 	/* internal buffer for download */
-	churl_buffer download_buffer;
+	churl_buffer *download_buffer;
 
 	/* internal buffer for upload */
-	churl_buffer upload_buffer;
+	churl_buffer *upload_buffer;
 
 	/*
 	 * holds http error code returned from remote server
@@ -99,11 +88,15 @@ typedef struct churl_context
 
 	/* true on upload, false on download */
 	bool		upload;
-
-	ResourceOwner owner; /* owner of this handle */
-	struct churl_context *next;
-	struct churl_context *prev;
 } churl_context;
+
+/*
+ * holds http header properties
+ */
+typedef struct churl_settings
+{
+	struct curl_slist *headers;
+} churl_settings;
 
 /* the null action object used for pure validation */
 static JsonSemAction nullSemAction =
@@ -112,10 +105,7 @@ static JsonSemAction nullSemAction =
 	NULL, NULL, NULL, NULL, NULL
 };
 
-static churl_context *open_curl_handles;
-static bool churl_resowner_callback_registered;
-
-static churl_context *churl_new_context(void);
+churl_context *churl_new_context(void);
 static void		create_curl_handle(churl_context *context);
 static void		set_curl_option(churl_context *context, CURLoption option, const void *data);
 static size_t	read_callback(void *ptr, size_t size, size_t nmemb, void *userdata);
@@ -128,6 +118,7 @@ static void		enlarge_internal_buffer(churl_buffer *buffer, size_t required);
 static void		finish_upload(churl_context *context);
 static void		cleanup_curl_handle(churl_context *context);
 static void		multi_remove_handle(churl_context *context);
+static void		cleanup_internal_buffer(churl_buffer *buffer);
 static void		churl_cleanup_context(churl_context *context);
 static size_t	write_callback(char *buffer, size_t size, size_t nitems, void *userp);
 static void		fill_internal_buffer(churl_context *context, int want);
@@ -322,6 +313,8 @@ churl_headers_cleanup(CHURL_HEADERS headers)
 
 	if (settings->headers)
 		curl_slist_free_all(settings->headers);
+
+	pfree(settings);
 }
 
 /*
@@ -365,9 +358,7 @@ log_curl_debug(CURL *handle, curl_infotype type, char *data, size_t size, void *
 static CHURL_HANDLE
 churl_init(const char *url, CHURL_HEADERS headers)
 {
-	churl_settings *settings = headers;
 	churl_context *context = churl_new_context();
-	context->churl_headers.headers = settings->headers;
 
 	create_curl_handle(context);
 	clear_error_buffer(context);
@@ -461,7 +452,7 @@ size_t
 churl_write(CHURL_HANDLE handle, const char *buf, size_t bufsize)
 {
 	churl_context *context = (churl_context *) handle;
-	churl_buffer *context_buffer = &context->upload_buffer;
+	churl_buffer *context_buffer = context->upload_buffer;
 
 	Assert(context->upload);
 
@@ -499,7 +490,7 @@ churl_read(CHURL_HANDLE handle, char *buf, size_t max_size)
 {
 	int			n = 0;
 	churl_context *context = (churl_context *) handle;
-	churl_buffer *context_buffer = &context->download_buffer;
+	churl_buffer *context_buffer = context->download_buffer;
 
 	Assert(!context->upload);
 
@@ -541,59 +532,18 @@ churl_cleanup(CHURL_HANDLE handle, bool after_error)
 	}
 
 	cleanup_curl_handle(context);
-	churl_headers_cleanup(&context->churl_headers);
+	cleanup_internal_buffer(context->download_buffer);
+	cleanup_internal_buffer(context->upload_buffer);
 	churl_cleanup_context(context);
 }
 
-static void
-churl_abort_callback(ResourceReleasePhase phase,
-						bool isCommit,
-						bool isTopLevel,
-						void *arg)
+churl_context *
+churl_new_context()
 {
-	churl_context *curr;
-	churl_context *next;
+	churl_context *context = palloc0(sizeof(churl_context));
 
-	if (phase != RESOURCE_RELEASE_AFTER_LOCKS)
-		return;
-
-	next = open_curl_handles;
-	while (next)
-	{
-		curr = next;
-		next = curr->next;
-
-		if (curr->owner == CurrentResourceOwner)
-		{
-			if (isCommit)
-				elog(LOG, "pxf reference leak: %p still referenced", curr);
-
-			churl_cleanup(curr, !isCommit);
-		}
-	}
-}
-
-static churl_context *
-churl_new_context(void)
-{
-	churl_context *context = MemoryContextAllocZero(TopMemoryContext, sizeof(churl_context));
-
-	context->owner = CurrentResourceOwner;
-
-	if (open_curl_handles)
-	{
-		context->next = open_curl_handles;
-		open_curl_handles->prev = context;
-	}
-
-	open_curl_handles = context;
-
-	if (!churl_resowner_callback_registered)
-	{
-		RegisterResourceReleaseCallback(churl_abort_callback, NULL);
-		churl_resowner_callback_registered = true;
-	}
-
+	context->download_buffer = palloc0(sizeof(churl_buffer));
+	context->upload_buffer = palloc0(sizeof(churl_buffer));
 	return context;
 }
 
@@ -632,7 +582,7 @@ static size_t
 read_callback(void *ptr, size_t size, size_t nmemb, void *userdata)
 {
 	churl_context *context = (churl_context *) userdata;
-	churl_buffer *context_buffer = &context->upload_buffer;
+	churl_buffer *context_buffer = context->upload_buffer;
 
 	int			written = Min(size * nmemb, context_buffer->top - context_buffer->bot);
 
@@ -695,7 +645,7 @@ internal_buffer_large_enough(churl_buffer *buffer, size_t required)
 static void
 flush_internal_buffer(churl_context *context)
 {
-	churl_buffer *context_buffer = &context->upload_buffer;
+	churl_buffer *context_buffer = context->upload_buffer;
 
 	if (context_buffer->top == 0)
 		return;
@@ -710,6 +660,8 @@ flush_internal_buffer(churl_context *context)
 
 		multi_perform(context);
 	}
+
+	check_response(context);
 
 	if ((context->curl_still_running == 0) &&
 		((context_buffer->top - context_buffer->bot) > 0))
@@ -795,17 +747,35 @@ multi_remove_handle(churl_context *context)
 }
 
 static void
+cleanup_internal_buffer(churl_buffer *buffer)
+{
+	if ((buffer) && (buffer->ptr))
+	{
+		pfree(buffer->ptr);
+		buffer->ptr = NULL;
+		buffer->bot = 0;
+		buffer->top = 0;
+		buffer->max = 0;
+	}
+}
+
+static void
 churl_cleanup_context(churl_context *context)
 {
 	if (context)
 	{
-		/* unlink from linked list first */
-		if (context->prev)
-			context->prev->next = context->next;
-		else
-			open_curl_handles = open_curl_handles->next;
-		if (context->next)
-			context->next->prev = context->prev;
+		if (context->download_buffer)
+		{
+			if (context->download_buffer->ptr)
+				pfree(context->download_buffer->ptr);
+			pfree(context->download_buffer);
+		}
+		if (context->upload_buffer)
+		{
+			if (context->upload_buffer->ptr)
+				pfree(context->upload_buffer->ptr);
+			pfree(context->upload_buffer);
+		}
 
 		pfree(context);
 	}
@@ -820,7 +790,7 @@ static size_t
 write_callback(char *buffer, size_t size, size_t nitems, void *userp)
 {
 	churl_context *context = (churl_context *) userp;
-	churl_buffer *context_buffer = &context->download_buffer;
+	churl_buffer *context_buffer = context->download_buffer;
 	const int	nbytes = size * nitems;
 
 	if (!internal_buffer_large_enough(context_buffer, nbytes))
@@ -852,7 +822,7 @@ fill_internal_buffer(churl_context *context, int want)
 
 	/* attempt to fill buffer */
 	while (context->curl_still_running &&
-		   ((context->download_buffer.top - context->download_buffer.bot) < want))
+		   ((context->download_buffer->top - context->download_buffer->bot) < want))
 	{
 		FD_ZERO(&fdread);
 		FD_ZERO(&fdwrite);
@@ -1014,10 +984,10 @@ check_response_code(churl_context *context)
 		initStringInfo(&err);
 
 		/* prepare response text if any */
-		if (context->download_buffer.ptr)
+		if (context->download_buffer->ptr)
 		{
-			context->download_buffer.ptr[context->download_buffer.top] = '\0';
-			response_text = context->download_buffer.ptr + context->download_buffer.bot;
+			context->download_buffer->ptr[context->download_buffer->top] = '\0';
+			response_text = context->download_buffer->ptr + context->download_buffer->bot;
 		}
 
 		appendStringInfo(&err, "PXF server error");

--- a/fdw/libchurl.c
+++ b/fdw/libchurl.c
@@ -396,6 +396,12 @@ churl_init(const char *url, CHURL_HEADERS headers)
 }
 
 CHURL_HANDLE
+churl_init_upload(const char *url, CHURL_HEADERS headers)
+{
+	return churl_init_upload_timeout(url, headers, 0);
+}
+
+CHURL_HANDLE
 churl_init_upload_timeout(const char *url, CHURL_HEADERS headers, long timeout)
 {
 	churl_context *context = churl_init(url, headers);
@@ -412,12 +418,6 @@ churl_init_upload_timeout(const char *url, CHURL_HEADERS headers, long timeout)
 
 	setup_multi_handle(context);
 	return (CHURL_HANDLE) context;
-}
-
-CHURL_HANDLE
-churl_init_upload(const char *url, CHURL_HEADERS headers)
-{
-	return churl_init_upload_timeout(url, headers, 0);
 }
 
 CHURL_HANDLE

--- a/fdw/libchurl.c
+++ b/fdw/libchurl.c
@@ -431,16 +431,16 @@ churl_init_download(const char *url, CHURL_HEADERS headers)
 	return (CHURL_HANDLE) context;
 }
 
-long
+int
 churl_get_local_port(CHURL_HANDLE handle)
 {
 	churl_context *context = (churl_context *) handle;
 
 	int curl_error;
-	long local_port;
+	long local_port = -1L;
 
 	if (CURLE_OK != (curl_error = curl_easy_getinfo(context->curl_handle, CURLINFO_LOCAL_PORT, &local_port)))
-		elog(ERROR, "internal error: curl_easy_getinfo failed(%d - %s)",
+		elog(WARNING, "internal error: curl_easy_getinfo failed(%d - %s)",
 			curl_error, curl_easy_strerror(curl_error));
 
 	return local_port;

--- a/fdw/libchurl.c
+++ b/fdw/libchurl.c
@@ -184,40 +184,6 @@ build_header_str(const char *format, const char *key, const char *value)
 	return header_option;
 }
 
-const char *
-churl_headers_value(CHURL_HEADERS headers, const char *key)
-{
-	churl_settings *settings = (churl_settings *) headers;
-	struct curl_slist *header_cell = settings->headers;
-	char	   *key_option = NULL;
-	char	   *header_data = NULL;
-	int			key_option_len;
-
-	/* key must not be empty */
-	Assert(key != NULL);
-
-	/* key to compare with in the headers */
-	key_option = build_header_str("%s: %s", key, "");
-	key_option_len = strlen(key_option);
-
-	/* find key in headers list */
-	while (header_cell != NULL)
-	{
-		header_data = header_cell->data;
-
-		if (strncmp(key_option, header_data, key_option_len) == 0)
-		{
-			elog(DEBUG2, "churl_headers_value: Found existing header %s with key %s",
-				 header_data, key_option);
-			return header_data + strlen(key) + 2;
-		}
-
-		header_cell = header_cell->next;
-	}
-
-	elog(ERROR, "churl_headers_value error: %s not found in headers", key);
-}
-
 void
 churl_headers_append(CHURL_HEADERS headers, const char *key, const char *value)
 {

--- a/fdw/libchurl.c
+++ b/fdw/libchurl.c
@@ -437,7 +437,7 @@ churl_get_local_port(CHURL_HANDLE handle)
 	churl_context *context = (churl_context *) handle;
 
 	int curl_error;
-	long local_port = -1L;
+	long local_port = 0;
 
 	if (CURLE_OK != (curl_error = curl_easy_getinfo(context->curl_handle, CURLINFO_LOCAL_PORT, &local_port)))
 		elog(WARNING, "internal error: curl_easy_getinfo failed(%d - %s)",

--- a/fdw/libchurl.c
+++ b/fdw/libchurl.c
@@ -209,7 +209,7 @@ churl_headers_override(CHURL_HEADERS headers, const char *key, const char *value
 	Assert(key != NULL);
 
 	/* key to compare with in the headers */
-	key_option = build_header_str("%s: %s", key, value ? "" : NULL);
+	key_option = build_header_str("%s:%s", key, value ? "" : NULL);
 
 	/* find key in headers list */
 	while (header_cell != NULL)
@@ -257,7 +257,7 @@ churl_headers_remove(CHURL_HEADERS headers, const char *key, bool has_value)
 	Assert(key != NULL);
 
 	/* key to compare with in the headers */
-	key_option = build_header_str("%s: %s", key, has_value ? "" : NULL);
+	key_option = build_header_str("%s:%s", key, has_value ? "" : NULL);
 
 	/* find key in headers list */
 	while (to_del_cell != NULL)

--- a/fdw/libchurl.c
+++ b/fdw/libchurl.c
@@ -435,7 +435,6 @@ int
 churl_get_local_port(CHURL_HANDLE handle)
 {
 	churl_context *context = (churl_context *) handle;
-
 	int curl_error;
 	long local_port = 0;
 

--- a/fdw/libchurl.c
+++ b/fdw/libchurl.c
@@ -431,8 +431,8 @@ churl_init_download(const char *url, CHURL_HEADERS headers)
 	return (CHURL_HANDLE) context;
 }
 
-void
-churl_set_local_port_to_headers(CHURL_HANDLE handle, CHURL_HEADERS headers)
+long
+churl_get_local_port(CHURL_HANDLE handle)
 {
 	churl_context *context = (churl_context *) handle;
 
@@ -443,7 +443,7 @@ churl_set_local_port_to_headers(CHURL_HANDLE handle, CHURL_HEADERS headers)
 		elog(ERROR, "internal error: curl_easy_getinfo failed(%d - %s)",
 			curl_error, curl_easy_strerror(curl_error));
 
-	churl_headers_override(headers, "X-GP-CLIENT-PORT", psprintf("%li", local_port));
+	return local_port;
 }
 
 void

--- a/fdw/libchurl.h
+++ b/fdw/libchurl.h
@@ -105,6 +105,10 @@ void		churl_headers_cleanup(CHURL_HEADERS headers);
  * returns a handle to churl transfer
  */
 CHURL_HANDLE churl_init_upload(const char *url, CHURL_HEADERS headers);
+CHURL_HANDLE churl_init_upload_timeout(const char *url, CHURL_HEADERS headers, long timeout);
+
+void		churl_set_local_port_to_headers(CHURL_HANDLE handle, CHURL_HEADERS headers);
+const char *churl_headers_value(CHURL_HEADERS headers, const char *key);
 
 /*
  * Start a download to url

--- a/fdw/libchurl.h
+++ b/fdw/libchurl.h
@@ -108,7 +108,6 @@ CHURL_HANDLE churl_init_upload(const char *url, CHURL_HEADERS headers);
 CHURL_HANDLE churl_init_upload_timeout(const char *url, CHURL_HEADERS headers, long timeout);
 
 void		churl_set_local_port_to_headers(CHURL_HANDLE handle, CHURL_HEADERS headers);
-const char *churl_headers_value(CHURL_HEADERS headers, const char *key);
 
 /*
  * Start a download to url

--- a/fdw/libchurl.h
+++ b/fdw/libchurl.h
@@ -107,7 +107,7 @@ void		churl_headers_cleanup(CHURL_HEADERS headers);
 CHURL_HANDLE churl_init_upload(const char *url, CHURL_HEADERS headers);
 CHURL_HANDLE churl_init_upload_timeout(const char *url, CHURL_HEADERS headers, long timeout);
 
-void		churl_set_local_port_to_headers(CHURL_HANDLE handle, CHURL_HEADERS headers);
+long		churl_get_local_port(CHURL_HANDLE handle);
 
 /*
  * Start a download to url

--- a/fdw/libchurl.h
+++ b/fdw/libchurl.h
@@ -107,6 +107,9 @@ void		churl_headers_cleanup(CHURL_HEADERS headers);
 CHURL_HANDLE churl_init_upload(const char *url, CHURL_HEADERS headers);
 CHURL_HANDLE churl_init_upload_timeout(const char *url, CHURL_HEADERS headers, long timeout);
 
+/*
+ * Returns local port of connected handle or 0
+ */
 long		churl_get_local_port(CHURL_HANDLE handle);
 
 /*

--- a/fdw/libchurl.h
+++ b/fdw/libchurl.h
@@ -110,7 +110,7 @@ CHURL_HANDLE churl_init_upload_timeout(const char *url, CHURL_HEADERS headers, l
 /*
  * Returns local port of connected handle or 0
  */
-long		churl_get_local_port(CHURL_HANDLE handle);
+int			churl_get_local_port(CHURL_HANDLE handle);
 
 /*
  * Start a download to url

--- a/fdw/pxf_bridge.c
+++ b/fdw/pxf_bridge.c
@@ -43,6 +43,10 @@ PxfBridgeCleanup(PxfFdwModifyState *pxfmstate)
 		return;
 
 	churl_cleanup(pxfmstate->churl_handle, false);
+	pxfmstate->churl_handle = NULL;
+
+	churl_headers_cleanup(pxfmstate->churl_headers);
+	pxfmstate->churl_headers = NULL;
 
 	if (pxfmstate->uri.data)
 	{
@@ -52,28 +56,6 @@ PxfBridgeCleanup(PxfFdwModifyState *pxfmstate)
 	if (pxfmstate->options)
 	{
 		pfree(pxfmstate->options);
-	}
-}
-
-/*
- * Clean up churl related data structures from the PXF FDW scan state.
- */
-void
-PxfBridgeScanCleanup(PxfFdwScanState *pxfsstate)
-{
-	if (pxfsstate == NULL)
-		return;
-
-	churl_cleanup(pxfsstate->churl_handle, false);
-
-	if (pxfsstate->uri.data)
-	{
-		pfree(pxfsstate->uri.data);
-	}
-
-	if (pxfsstate->options)
-	{
-		pfree(pxfsstate->options);
 	}
 }
 

--- a/fdw/pxf_bridge.c
+++ b/fdw/pxf_bridge.c
@@ -102,7 +102,10 @@ PxfBridgeImportCleanup(PxfFdwScanState *pxfsstate)
 			InterruptHoldoffCount = savedInterruptHoldoffCount;
 
 			if (!elog_dismiss(WARNING))
+			{
+				FlushErrorState();
 				elog(WARNING, "unable to dismiss error");
+			}
 		}
 		PG_END_TRY();
 	}

--- a/fdw/pxf_bridge.c
+++ b/fdw/pxf_bridge.c
@@ -224,11 +224,10 @@ PxfBridgeWrite(PxfFdwModifyState *pxfmstate, char *databuf, int datalen)
 static void
 BuildUriForCancel(PxfFdwScanState *pxfsstate)
 {
-	const char *host = churl_headers_value(pxfsstate->churl_headers, "X-GP-URL-HOST");
-	const char *port = churl_headers_value(pxfsstate->churl_headers, "X-GP-URL-PORT");
+	PxfOptions *options = pxfsstate->options;
 
 	resetStringInfo(&pxfsstate->uri);
-	appendStringInfo(&pxfsstate->uri, "http://%s:%s/%s/cancel", host, port, PXF_SERVICE_PREFIX);
+	appendStringInfo(&pxfsstate->uri, "http://%s:%d/%s/cancel", options->pxf_host, options->pxf_port, PXF_SERVICE_PREFIX);
 	elog(DEBUG2, "pxf_fdw: uri %s for cancel", pxfsstate->uri.data);
 }
 

--- a/fdw/pxf_bridge.c
+++ b/fdw/pxf_bridge.c
@@ -151,7 +151,7 @@ PxfBridgeImportStart(PxfFdwScanState *pxfsstate)
 	MemoryContextSwitchTo(oldcontext);
 	pxfcstate->churl_headers = pxfsstate->churl_headers;
 	pxfcstate->churl_handle = pxfsstate->churl_handle;
-	pxfcstate->owner = CurrentResourceOwner;
+	pxfcstate->owner = CurTransactionResourceOwner;
 	pxfcstate->pxf_port = pxfsstate->options->pxf_port;
 	RegisterResourceReleaseCallback(PxfBridgeAbortCallback, pxfcstate);
 

--- a/fdw/pxf_bridge.c
+++ b/fdw/pxf_bridge.c
@@ -162,7 +162,7 @@ PxfBridgeImportStart(PxfFdwScanState *pxfsstate)
 					 pxfsstate->projectionInfo);
 
 	pxfsstate->common->churl_handle = churl_init_download(pxfsstate->common->uri.data, pxfsstate->common->churl_headers);
-	pxfsstate->common->owner = CurTransactionResourceOwner;
+	pxfsstate->common->owner = CurrentResourceOwner;
 
 	RegisterResourceReleaseCallback(PxfBridgeAbortCallback, pxfsstate->common);
 

--- a/fdw/pxf_bridge.c
+++ b/fdw/pxf_bridge.c
@@ -74,16 +74,16 @@ PxfBridgeCancel(PxfFdwCancelState *pxfcstate)
 	if (!IsAbortInProgress())
 		return;
 
-	long local_port = churl_get_local_port(pxfcstate->churl_handle);
+	int local_port = churl_get_local_port(pxfcstate->churl_handle);
 
-	if (local_port == 0)
+	if (local_port <= 0)
 		return;
 
 	int savedInterruptHoldoffCount = InterruptHoldoffCount;
 
 	PG_TRY();
 	{
-		churl_headers_append(pxfcstate->churl_headers, "X-GP-CLIENT-PORT", psprintf("%li", local_port));
+		churl_headers_append(pxfcstate->churl_headers, "X-GP-CLIENT-PORT", psprintf("%i", local_port));
 
 		char *uri = BuildUriForCancel(pxfcstate);
 

--- a/fdw/pxf_bridge.c
+++ b/fdw/pxf_bridge.c
@@ -37,7 +37,6 @@ typedef struct PxfFdwCancelState
 } PxfFdwCancelState;
 
 /* helper function declarations */
-static void PxfBridgeCancel(PxfFdwCancelState *pxfcstate);
 static void PxfBridgeCancelCleanup(PxfFdwCancelState *pxfcstate);
 static void BuildUriForCancel(PxfFdwCancelState *pxfcstate);
 static void BuildUriForRead(PxfFdwScanState *pxfsstate);

--- a/fdw/pxf_bridge.c
+++ b/fdw/pxf_bridge.c
@@ -136,7 +136,10 @@ PxfBridgeCleanup(PxfFdwModifyState *pxfmstate)
 void
 PxfBridgeImportStart(PxfFdwScanState *pxfsstate)
 {
-	MemoryContext oldcontext = MemoryContextSwitchTo(CurTransactionContext);
+	MemoryContext oldcontext;
+	PxfFdwCancelState *pxfcstate;
+
+	oldcontext = MemoryContextSwitchTo(CurTransactionContext);
 	pxfsstate->churl_headers = churl_headers_init();
 	MemoryContextSwitchTo(oldcontext);
 
@@ -151,7 +154,7 @@ PxfBridgeImportStart(PxfFdwScanState *pxfsstate)
 	oldcontext = MemoryContextSwitchTo(CurTransactionContext);
 	pxfsstate->churl_handle = churl_init_download(pxfsstate->uri.data, pxfsstate->churl_headers);
 
-	PxfFdwCancelState *pxfcstate = palloc0(sizeof(PxfFdwCancelState));
+	pxfcstate = palloc0(sizeof(PxfFdwCancelState));
 	pxfcstate->pxf_host = pstrdup(pxfsstate->options->pxf_host);
 	MemoryContextSwitchTo(oldcontext);
 	pxfcstate->churl_headers = pxfsstate->churl_headers;

--- a/fdw/pxf_bridge.c
+++ b/fdw/pxf_bridge.c
@@ -56,7 +56,8 @@ PxfBridgeAbortCallback(ResourceReleasePhase phase,
 	}
 }
 
-static void PxfBridgeCancel(PxfFdwCommonState *common)
+static void
+PxfBridgeCancel(PxfFdwCommonState *common)
 {
 	UnregisterResourceReleaseCallback(PxfBridgeAbortCallback, common);
 

--- a/fdw/pxf_bridge.c
+++ b/fdw/pxf_bridge.c
@@ -148,16 +148,16 @@ PxfBridgeImportStart(PxfFdwScanState *pxfsstate)
 					 pxfsstate->retrieved_attrs,
 					 pxfsstate->projectionInfo);
 
+	oldcontext = MemoryContextSwitchTo(CurTransactionContext);
 	pxfsstate->churl_handle = churl_init_download(pxfsstate->uri.data, pxfsstate->churl_headers);
 
-	oldcontext = MemoryContextSwitchTo(CurTransactionContext);
 	PxfFdwCancelState *pxfcstate = palloc0(sizeof(PxfFdwCancelState));
+	pxfcstate->pxf_host = pstrdup(pxfsstate->options->pxf_host);
+	MemoryContextSwitchTo(oldcontext);
 	pxfcstate->churl_headers = pxfsstate->churl_headers;
 	pxfcstate->churl_handle = pxfsstate->churl_handle;
 	pxfcstate->owner = CurrentResourceOwner;
-	pxfcstate->pxf_host = pstrdup(pxfsstate->options->pxf_host);
 	pxfcstate->pxf_port = pxfsstate->options->pxf_port;
-	MemoryContextSwitchTo(oldcontext);
 	RegisterResourceReleaseCallback(PxfBridgeAbortCallback, pxfcstate);
 
 	/* read some bytes to make sure the connection is established */

--- a/fdw/pxf_bridge.c
+++ b/fdw/pxf_bridge.c
@@ -311,7 +311,7 @@ FillBuffer(PxfFdwScanState *pxfsstate, char *start, size_t size)
 
 	while (ptr < minend)
 	{
-		n = churl_read(pxfsstate->common->churl_handle, ptr, maxend - ptr);
+		n = churl_read(pxfsstate->churl_handle, ptr, maxend - ptr);
 #else
 	char	   *end = ptr + size;
 

--- a/fdw/pxf_bridge.c
+++ b/fdw/pxf_bridge.c
@@ -112,9 +112,6 @@ PxfBridgeCancelCleanup(PxfFdwCancelState *pxfcstate)
 	if (IsAbortInProgress())
 		PxfBridgeCancel(pxfcstate);
 
-	if (pxfcstate->uri.data)
-		pfree(pxfcstate->uri.data);
-
 	if (pxfcstate->pxf_host)
 		pfree(pxfcstate->pxf_host);
 

--- a/fdw/pxf_bridge.c
+++ b/fdw/pxf_bridge.c
@@ -58,12 +58,7 @@ PxfBridgeAbortCallback(ResourceReleasePhase phase,
 		return;
 
 	if (pxfcstate->owner == CurrentResourceOwner)
-	{
-		if (isCommit)
-			elog(LOG, "pxf BridgeImport reference leak: %p still referenced", arg);
-
 		PxfBridgeCancel(pxfcstate);
-	}
 }
 
 static void

--- a/fdw/pxf_bridge.c
+++ b/fdw/pxf_bridge.c
@@ -139,6 +139,7 @@ PxfBridgeImportStart(PxfFdwScanState *pxfsstate)
 	MemoryContext oldcontext = MemoryContextSwitchTo(CurTransactionContext);
 	pxfsstate->churl_headers = churl_headers_init();
 	MemoryContextSwitchTo(oldcontext);
+
 	BuildUriForRead(pxfsstate);
 	BuildHttpHeaders(pxfsstate->churl_headers,
 					 pxfsstate->options,

--- a/fdw/pxf_bridge.c
+++ b/fdw/pxf_bridge.c
@@ -56,7 +56,7 @@ PxfBridgeAbortCallback(ResourceReleasePhase phase,
 }
 
 /*
- * Clean up churl related data structures from the PXF FDW scan state.
+ * Clean up churl related data structures from the PXF FDW scan/modify state.
  */
 void
 PxfBridgeCleanup(PxfFdwCommonState *common)

--- a/fdw/pxf_bridge.c
+++ b/fdw/pxf_bridge.c
@@ -105,7 +105,7 @@ PxfBridgeImportCleanup(PxfFdwScanState *pxfsstate)
 			pxfsstate->cleanup.arg = pxfsstate;
 			pxfsstate->cleanup.func = PxfBridgeImportAbortCallback;
 
-			MemoryContextRegisterResetCallback(CurrentMemoryContext, &pxfsstate->cleanup);
+			//MemoryContextRegisterResetCallback(CurrentMemoryContext, &pxfsstate->cleanup);
 
 			churl_cleanup(pxfsstate->churl_handle, false);
 		}

--- a/fdw/pxf_bridge.c
+++ b/fdw/pxf_bridge.c
@@ -71,7 +71,7 @@ PxfBridgeCancel(PxfFdwCancelState *pxfcstate)
 
 	int local_port = churl_get_local_port(pxfcstate->churl_handle);
 
-	if (local_port <= 0)
+	if (local_port == 0)
 		return;
 
 	int savedInterruptHoldoffCount = InterruptHoldoffCount;

--- a/fdw/pxf_bridge.c
+++ b/fdw/pxf_bridge.c
@@ -82,6 +82,7 @@ PxfBridgeCancel(PxfFdwCancelState *pxfcstate)
 
 		churl_headers_append(pxfcstate->churl_headers, "X-GP-CLIENT-PORT", psprintf("%i", local_port));
 
+		initStringInfo(&pxfcstate->uri);
 		BuildUriForCancel(pxfcstate);
 		churl_handle = churl_init_upload_timeout(pxfcstate->uri.data, pxfcstate->churl_headers, 1L);
 
@@ -198,10 +199,9 @@ PxfBridgeImportStart(PxfFdwScanState *pxfsstate)
 
 	oldcontext = MemoryContextSwitchTo(CurTransactionContext);
 	pxfcstate = palloc0(sizeof(PxfFdwCancelState));
-	pxfsstate->pxfcstate = pxfcstate;
 	pxfcstate->pxf_host = pstrdup(pxfsstate->options->pxf_host);
-	initStringInfo(&pxfcstate->uri);
 	MemoryContextSwitchTo(oldcontext);
+	pxfsstate->pxfcstate = pxfcstate;
 	pxfcstate->churl_headers = pxfsstate->churl_headers;
 	pxfcstate->churl_handle = pxfsstate->churl_handle;
 	pxfcstate->owner = CurTransactionResourceOwner;

--- a/fdw/pxf_bridge.c
+++ b/fdw/pxf_bridge.c
@@ -139,9 +139,7 @@ PxfBridgeImportStart(PxfFdwScanState *pxfsstate)
 	MemoryContext oldcontext;
 	PxfFdwCancelState *pxfcstate;
 
-	oldcontext = MemoryContextSwitchTo(CurTransactionContext);
 	pxfsstate->churl_headers = churl_headers_init();
-	MemoryContextSwitchTo(oldcontext);
 
 	BuildUriForRead(pxfsstate);
 	BuildHttpHeaders(pxfsstate->churl_headers,
@@ -151,9 +149,9 @@ PxfBridgeImportStart(PxfFdwScanState *pxfsstate)
 					 pxfsstate->retrieved_attrs,
 					 pxfsstate->projectionInfo);
 
-	oldcontext = MemoryContextSwitchTo(CurTransactionContext);
 	pxfsstate->churl_handle = churl_init_download(pxfsstate->uri.data, pxfsstate->churl_headers);
 
+	oldcontext = MemoryContextSwitchTo(CurTransactionContext);
 	pxfcstate = palloc0(sizeof(PxfFdwCancelState));
 	pxfcstate->pxf_host = pstrdup(pxfsstate->options->pxf_host);
 	initStringInfo(&pxfcstate->uri);

--- a/fdw/pxf_bridge.c
+++ b/fdw/pxf_bridge.c
@@ -105,32 +105,6 @@ PxfBridgeCancel(PxfFdwCancelState *pxfcstate)
 }
 
 /*
- * Clean up churl related data structures from the PXF FDW scan state.
- */
-void
-PxfBridgeImportCleanup(PxfFdwScanState *pxfsstate)
-{
-	if (pxfsstate == NULL)
-		return;
-
-	churl_cleanup(pxfsstate->churl_handle, false);
-	pxfsstate->churl_handle = NULL;
-
-	churl_headers_cleanup(pxfsstate->churl_headers);
-	pxfsstate->churl_headers = NULL;
-
-	if (pxfsstate->uri.data)
-	{
-		pfree(pxfsstate->uri.data);
-	}
-
-	if (pxfsstate->options)
-	{
-		pfree(pxfsstate->options);
-	}
-}
-
-/*
  * Clean up churl related data structures from the PXF FDW modify state.
  */
 void

--- a/fdw/pxf_bridge.c
+++ b/fdw/pxf_bridge.c
@@ -84,7 +84,8 @@ PxfBridgeImportCleanup(PxfFdwScanState *pxfsstate)
 
 		PG_TRY();
 		{
-			churl_set_local_port_to_headers(pxfsstate->churl_handle, pxfsstate->churl_headers);
+			long local_port = churl_get_local_port(pxfsstate->churl_handle);
+			churl_headers_override(pxfsstate->churl_headers, "X-GP-CLIENT-PORT", psprintf("%li", local_port));
 
 			churl_cleanup(pxfsstate->churl_handle, true);
 			pxfsstate->churl_handle = NULL;

--- a/fdw/pxf_bridge.c
+++ b/fdw/pxf_bridge.c
@@ -114,6 +114,9 @@ PxfBridgeCancelCleanup(PxfFdwCancelState *pxfcstate)
 	if (pxfcstate->uri.data)
 		pfree(pxfcstate->uri.data);
 
+	if (pxfcstate->pxf_host)
+		pfree(pxfcstate->pxf_host);
+
 	pfree(pxfcstate);
 }
 

--- a/fdw/pxf_bridge.c
+++ b/fdw/pxf_bridge.c
@@ -80,12 +80,10 @@ PxfBridgeImportCleanup(PxfFdwScanState *pxfsstate)
 
 	if (IsAbortInProgress())
 	{
-		int savedInterruptHoldoffCount;
+		int savedInterruptHoldoffCount = InterruptHoldoffCount;
 
 		PG_TRY();
 		{
-			savedInterruptHoldoffCount = InterruptHoldoffCount;
-
 			churl_set_local_port_to_headers(pxfsstate->churl_handle, pxfsstate->churl_headers);
 
 			churl_cleanup(pxfsstate->churl_handle, true);

--- a/fdw/pxf_bridge.c
+++ b/fdw/pxf_bridge.c
@@ -78,7 +78,7 @@ PxfBridgeCleanup(PxfFdwCommonState *common)
 		{
 			PG_TRY();
 			{
-				churl_headers_override(common->churl_headers, "X-GP-CLIENT-PORT", psprintf("%li", local_port));
+				churl_headers_append(common->churl_headers, "X-GP-CLIENT-PORT", psprintf("%li", local_port));
 
 				BuildUriForCancel(common);
 

--- a/fdw/pxf_bridge.h
+++ b/fdw/pxf_bridge.h
@@ -76,7 +76,6 @@ typedef struct PxfFdwModifyState
 
 /* Clean up churl related data structures from the context */
 void		PxfBridgeCleanup(PxfFdwModifyState *context);
-void		PxfBridgeScanCleanup(PxfFdwScanState *context);
 
 /* Sets up data before starting import */
 void		PxfBridgeImportStart(PxfFdwScanState *pxfsstate);

--- a/fdw/pxf_bridge.h
+++ b/fdw/pxf_bridge.h
@@ -53,6 +53,7 @@ typedef struct PxfFdwScanState
 	PxfOptions *options;
 	CopyState	cstate;
 	ProjectionInfo *projectionInfo;
+	void           *pxfcstate;
 } PxfFdwScanState;
 
 /*

--- a/fdw/pxf_bridge.h
+++ b/fdw/pxf_bridge.h
@@ -53,6 +53,7 @@ typedef struct PxfFdwScanState
 	PxfOptions *options;
 	CopyState	cstate;
 	ProjectionInfo *projectionInfo;
+	MemoryContextCallback cleanup;
 } PxfFdwScanState;
 
 /*
@@ -76,6 +77,7 @@ typedef struct PxfFdwModifyState
 
 /* Clean up churl related data structures from the context */
 void		PxfBridgeCleanup(PxfFdwModifyState *context);
+void		PxfBridgeImportCleanup(PxfFdwScanState *pxfsstate);
 
 /* Sets up data before starting import */
 void		PxfBridgeImportStart(PxfFdwScanState *pxfsstate);

--- a/fdw/pxf_bridge.h
+++ b/fdw/pxf_bridge.h
@@ -34,21 +34,13 @@
 #define PXF_SEGMENT_ID                 GpIdentity.segindex
 #define PXF_SEGMENT_COUNT              getgpsegmentCount()
 
-typedef struct PxfFdwCommonState
-{
-	CHURL_HEADERS churl_headers;
-	CHURL_HANDLE churl_handle;
-	ResourceOwner owner;
-	int			pxf_port;		/* port number for the PXF Service */
-	char	   *pxf_host;		/* hostname for the PXF Service */
-} PxfFdwCommonState;
-
 /*
  * Execution state of a foreign scan using pxf_fdw.
  */
 typedef struct PxfFdwScanState
 {
-	PxfFdwCommonState *common;
+	CHURL_HEADERS churl_headers;
+	CHURL_HANDLE churl_handle;
 	StringInfoData uri;
 	Relation	relation;
 	char	   *filter_str;

--- a/fdw/pxf_bridge.h
+++ b/fdw/pxf_bridge.h
@@ -74,6 +74,7 @@ typedef struct PxfFdwModifyState
 	Datum	   *values;			/* List of values exported for the row */
 	bool	   *nulls;			/* List of null fields for the exported row */
 #endif
+	MemoryContextCallback cleanup;
 } PxfFdwModifyState;
 
 /* Clean up churl related data structures from the context */

--- a/fdw/pxf_bridge.h
+++ b/fdw/pxf_bridge.h
@@ -41,7 +41,6 @@ typedef struct PxfFdwCommonState
 	StringInfoData uri;
 	PxfOptions *options;
 	ResourceOwner owner;
-	bool upload;
 } PxfFdwCommonState;
 
 /*
@@ -67,10 +66,13 @@ typedef struct PxfFdwScanState
  */
 typedef struct PxfFdwModifyState
 {
-	PxfFdwCommonState *common;
 	CopyState	cstate;			/* state of writing to PXF */
 
+	CHURL_HANDLE churl_handle;	/* curl handle */
+	CHURL_HEADERS churl_headers;	/* curl headers */
+	StringInfoData uri;			/* rest endpoint URI for modify */
 	Relation	relation;
+	PxfOptions *options;		/* FDW options */
 
 #if PG_VERSION_NUM < 90600
 	Datum	   *values;			/* List of values exported for the row */
@@ -79,7 +81,8 @@ typedef struct PxfFdwModifyState
 } PxfFdwModifyState;
 
 /* Clean up churl related data structures from the context */
-void		PxfBridgeCleanup(PxfFdwCommonState *common);
+void		PxfBridgeImportCleanup(PxfFdwCommonState *common);
+void		PxfBridgeCleanup(PxfFdwModifyState *context);
 
 /* Sets up data before starting import */
 void		PxfBridgeImportStart(PxfFdwScanState *pxfsstate);

--- a/fdw/pxf_bridge.h
+++ b/fdw/pxf_bridge.h
@@ -54,6 +54,7 @@ typedef struct PxfFdwScanState
 	CopyState	cstate;
 	ProjectionInfo *projectionInfo;
 	MemoryContextCallback cleanup;
+	bool		cancel_request;
 } PxfFdwScanState;
 
 /*

--- a/fdw/pxf_bridge.h
+++ b/fdw/pxf_bridge.h
@@ -79,8 +79,7 @@ typedef struct PxfFdwModifyState
 } PxfFdwModifyState;
 
 /* Clean up churl related data structures from the context */
-void		PxfBridgeCleanup(PxfFdwModifyState *context);
-void		PxfBridgeImportCleanup(PxfFdwScanState *pxfsstate);
+void		PxfBridgeCleanup(PxfFdwCommonState *common);
 
 /* Sets up data before starting import */
 void		PxfBridgeImportStart(PxfFdwScanState *pxfsstate);

--- a/fdw/pxf_bridge.h
+++ b/fdw/pxf_bridge.h
@@ -54,7 +54,6 @@ typedef struct PxfFdwScanState
 	CopyState	cstate;
 	ProjectionInfo *projectionInfo;
 	ResourceOwner owner;
-	bool		cancel_request;
 } PxfFdwScanState;
 
 /*

--- a/fdw/pxf_bridge.h
+++ b/fdw/pxf_bridge.h
@@ -53,7 +53,7 @@ typedef struct PxfFdwScanState
 	PxfOptions *options;
 	CopyState	cstate;
 	ProjectionInfo *projectionInfo;
-	MemoryContextCallback cleanup;
+	ResourceOwner owner;
 	bool		cancel_request;
 } PxfFdwScanState;
 
@@ -74,7 +74,7 @@ typedef struct PxfFdwModifyState
 	Datum	   *values;			/* List of values exported for the row */
 	bool	   *nulls;			/* List of null fields for the exported row */
 #endif
-	MemoryContextCallback cleanup;
+	ResourceOwner owner;
 } PxfFdwModifyState;
 
 /* Clean up churl related data structures from the context */

--- a/fdw/pxf_bridge.h
+++ b/fdw/pxf_bridge.h
@@ -38,9 +38,9 @@ typedef struct PxfFdwCommonState
 {
 	CHURL_HEADERS churl_headers;
 	CHURL_HANDLE churl_handle;
-	StringInfoData uri;
-	PxfOptions *options;
 	ResourceOwner owner;
+	int			pxf_port;		/* port number for the PXF Service */
+	char	   *pxf_host;		/* hostname for the PXF Service */
 } PxfFdwCommonState;
 
 /*
@@ -49,6 +49,7 @@ typedef struct PxfFdwCommonState
 typedef struct PxfFdwScanState
 {
 	PxfFdwCommonState *common;
+	StringInfoData uri;
 	Relation	relation;
 	char	   *filter_str;
 #if PG_VERSION_NUM >= 90600
@@ -57,6 +58,7 @@ typedef struct PxfFdwScanState
 	List	   *quals;
 #endif
 	List	   *retrieved_attrs;
+	PxfOptions *options;
 	CopyState	cstate;
 	ProjectionInfo *projectionInfo;
 } PxfFdwScanState;
@@ -81,7 +83,7 @@ typedef struct PxfFdwModifyState
 } PxfFdwModifyState;
 
 /* Clean up churl related data structures from the context */
-void		PxfBridgeImportCleanup(PxfFdwCommonState *common);
+void		PxfBridgeImportCleanup(PxfFdwScanState *pxfsstate);
 void		PxfBridgeCleanup(PxfFdwModifyState *context);
 
 /* Sets up data before starting import */

--- a/fdw/pxf_bridge.h
+++ b/fdw/pxf_bridge.h
@@ -34,14 +34,22 @@
 #define PXF_SEGMENT_ID                 GpIdentity.segindex
 #define PXF_SEGMENT_COUNT              getgpsegmentCount()
 
+typedef struct PxfFdwCommonState
+{
+	CHURL_HEADERS churl_headers;
+	CHURL_HANDLE churl_handle;
+	StringInfoData uri;
+	PxfOptions *options;
+	ResourceOwner owner;
+	bool upload;
+} PxfFdwCommonState;
+
 /*
  * Execution state of a foreign scan using pxf_fdw.
  */
 typedef struct PxfFdwScanState
 {
-	CHURL_HEADERS churl_headers;
-	CHURL_HANDLE churl_handle;
-	StringInfoData uri;
+	PxfFdwCommonState *common;
 	Relation	relation;
 	char	   *filter_str;
 #if PG_VERSION_NUM >= 90600
@@ -50,10 +58,8 @@ typedef struct PxfFdwScanState
 	List	   *quals;
 #endif
 	List	   *retrieved_attrs;
-	PxfOptions *options;
 	CopyState	cstate;
 	ProjectionInfo *projectionInfo;
-	ResourceOwner owner;
 } PxfFdwScanState;
 
 /*
@@ -61,19 +67,15 @@ typedef struct PxfFdwScanState
  */
 typedef struct PxfFdwModifyState
 {
+	PxfFdwCommonState *common;
 	CopyState	cstate;			/* state of writing to PXF */
 
-	CHURL_HANDLE churl_handle;	/* curl handle */
-	CHURL_HEADERS churl_headers;	/* curl headers */
-	StringInfoData uri;			/* rest endpoint URI for modify */
 	Relation	relation;
-	PxfOptions *options;		/* FDW options */
 
 #if PG_VERSION_NUM < 90600
 	Datum	   *values;			/* List of values exported for the row */
 	bool	   *nulls;			/* List of null fields for the exported row */
 #endif
-	ResourceOwner owner;
 } PxfFdwModifyState;
 
 /* Clean up churl related data structures from the context */

--- a/fdw/pxf_bridge.h
+++ b/fdw/pxf_bridge.h
@@ -75,7 +75,6 @@ typedef struct PxfFdwModifyState
 } PxfFdwModifyState;
 
 /* Clean up churl related data structures from the context */
-void		PxfBridgeImportCleanup(PxfFdwScanState *pxfsstate);
 void		PxfBridgeCleanup(PxfFdwModifyState *context);
 
 /* Sets up data before starting import */

--- a/fdw/pxf_fdw.c
+++ b/fdw/pxf_fdw.c
@@ -436,6 +436,7 @@ pxfBeginForeignScan(ForeignScanState *node, int eflags)
 	pxfsstate->relation = relation;
 	pxfsstate->retrieved_attrs = retrieved_attrs;
 	pxfsstate->projectionInfo = node->ss.ps.ps_ProjInfo;
+	pxfsstate->pxfcstate = NULL;
 
     /* Set up callback to identify error foreign relation. */
     ErrorContextCallback errcallback;

--- a/fdw/pxf_fdw.c
+++ b/fdw/pxf_fdw.c
@@ -568,8 +568,6 @@ pxfEndForeignScan(ForeignScanState *node)
 	if (pxfsstate)
 		EndCopyFrom(pxfsstate->cstate);
 
-	PxfBridgeScanCleanup(pxfsstate);
-
 	elog(DEBUG5, "pxf_fdw: pxfEndForeignScan ends on segment: %d", PXF_SEGMENT_ID);
 }
 

--- a/fdw/pxf_fdw.c
+++ b/fdw/pxf_fdw.c
@@ -784,9 +784,7 @@ InitCopyState(PxfFdwScanState *pxfsstate)
 {
 	CopyState	cstate;
 
-	MemoryContext oldcontext = MemoryContextSwitchTo(CurTransactionContext);
 	PxfBridgeImportStart(pxfsstate);
-	MemoryContextSwitchTo(oldcontext);
 
 	/*
 	 * Create CopyState from FDW options.  We always acquire all columns, so

--- a/fdw/pxf_fdw.c
+++ b/fdw/pxf_fdw.c
@@ -427,7 +427,7 @@ pxfBeginForeignScan(ForeignScanState *node, int eflags)
 	 * Save state in node->fdw_state.  We must save enough information to call
 	 * BeginCopyFrom() again.
 	 */
-	pxfsstate = palloc(sizeof(PxfFdwScanState));
+	pxfsstate = palloc0(sizeof(PxfFdwScanState));
 	initStringInfo(&pxfsstate->uri);
 
 	pxfsstate->filter_str = filter_str;

--- a/fdw/pxf_fdw.c
+++ b/fdw/pxf_fdw.c
@@ -427,7 +427,7 @@ pxfBeginForeignScan(ForeignScanState *node, int eflags)
 	 * Save state in node->fdw_state.  We must save enough information to call
 	 * BeginCopyFrom() again.
 	 */
-	pxfsstate = palloc(sizeof(PxfFdwScanState));
+	pxfsstate = (PxfFdwScanState *) palloc(sizeof(PxfFdwScanState));
 	initStringInfo(&pxfsstate->uri);
 
 	pxfsstate->filter_str = filter_str;

--- a/fdw/pxf_fdw.c
+++ b/fdw/pxf_fdw.c
@@ -568,7 +568,6 @@ pxfEndForeignScan(ForeignScanState *node)
 	if (pxfsstate)
 		EndCopyFrom(pxfsstate->cstate);
 
-	PxfBridgeImportCleanup(pxfsstate);
 	elog(DEBUG5, "pxf_fdw: pxfEndForeignScan ends on segment: %d", PXF_SEGMENT_ID);
 }
 

--- a/fdw/pxf_fdw.c
+++ b/fdw/pxf_fdw.c
@@ -571,7 +571,7 @@ pxfEndForeignScan(ForeignScanState *node)
 	if (pxfsstate)
 		EndCopyFrom(pxfsstate->cstate);
 
-	PxfBridgeImportCleanup(pxfsstate);
+	PxfBridgeCleanup(pxfsstate->common);
 	elog(DEBUG5, "pxf_fdw: pxfEndForeignScan ends on segment: %d", PXF_SEGMENT_ID);
 }
 
@@ -762,7 +762,7 @@ FinishForeignModify(PxfFdwModifyState *pxfmstate)
 
 	EndCopyFrom(pxfmstate->cstate);
 	pxfmstate->cstate = NULL;
-	PxfBridgeCleanup(pxfmstate);
+	PxfBridgeCleanup(pxfmstate->common);
 
 }
 

--- a/fdw/pxf_fdw.c
+++ b/fdw/pxf_fdw.c
@@ -427,7 +427,7 @@ pxfBeginForeignScan(ForeignScanState *node, int eflags)
 	 * Save state in node->fdw_state.  We must save enough information to call
 	 * BeginCopyFrom() again.
 	 */
-	pxfsstate = (PxfFdwScanState *) palloc(sizeof(PxfFdwScanState));
+	pxfsstate = (PxfFdwScanState *) palloc0(sizeof(PxfFdwScanState));
 	initStringInfo(&pxfsstate->uri);
 
 	pxfsstate->filter_str = filter_str;
@@ -639,7 +639,7 @@ InitForeignModify(Relation relation)
 
 	tupDesc = RelationGetDescr(relation);
 	options = PxfGetOptions(foreigntableid);
-	pxfmstate = palloc(sizeof(PxfFdwModifyState));
+	pxfmstate = palloc0(sizeof(PxfFdwModifyState));
 
 	initStringInfo(&pxfmstate->uri);
 	pxfmstate->relation = relation;
@@ -756,8 +756,6 @@ FinishForeignModify(PxfFdwModifyState *pxfmstate)
 
 	EndCopyFrom(pxfmstate->cstate);
 	pxfmstate->cstate = NULL;
-	PxfBridgeCleanup(pxfmstate);
-
 }
 
 /*

--- a/fdw/pxf_fdw.c
+++ b/fdw/pxf_fdw.c
@@ -412,7 +412,7 @@ pxfBeginForeignScan(ForeignScanState *node, int eflags)
 	PxfFdwScanState *pxfsstate    = NULL;
 	Relation	relation          = node->ss.ss_currentRelation;
 	ForeignScan *foreignScan      = (ForeignScan *) node->ss.ps.plan;
-	PxfOptions *options           = PxfGetOptions(foreigntableid);
+	PxfOptions *options           = NULL;
 
 	/* retrieve fdw-private information from pxfGetForeignPlan() */
 	char *filter_str              = strVal(list_nth(foreignScan->fdw_private, FdwScanPrivateWhereClauses));
@@ -427,8 +427,11 @@ pxfBeginForeignScan(ForeignScanState *node, int eflags)
 	 * Save state in node->fdw_state.  We must save enough information to call
 	 * BeginCopyFrom() again.
 	 */
+	MemoryContext oldcontext = MemoryContextSwitchTo(CurTransactionContext);
+	options = PxfGetOptions(foreigntableid);
 	pxfsstate = (PxfFdwScanState *) palloc0(sizeof(PxfFdwScanState));
 	initStringInfo(&pxfsstate->uri);
+	MemoryContextSwitchTo(oldcontext);
 
 	pxfsstate->filter_str = filter_str;
 	pxfsstate->options = options;
@@ -568,6 +571,7 @@ pxfEndForeignScan(ForeignScanState *node)
 	if (pxfsstate)
 		EndCopyFrom(pxfsstate->cstate);
 
+	PxfBridgeImportCleanup(pxfsstate);
 	elog(DEBUG5, "pxf_fdw: pxfEndForeignScan ends on segment: %d", PXF_SEGMENT_ID);
 }
 
@@ -638,10 +642,12 @@ InitForeignModify(Relation relation)
 		return NULL;
 
 	tupDesc = RelationGetDescr(relation);
+	MemoryContext oldcontext = MemoryContextSwitchTo(CurTransactionContext);
 	options = PxfGetOptions(foreigntableid);
 	pxfmstate = palloc0(sizeof(PxfFdwModifyState));
 
 	initStringInfo(&pxfmstate->uri);
+	MemoryContextSwitchTo(oldcontext);
 	pxfmstate->relation = relation;
 	pxfmstate->options = options;
 #if PG_VERSION_NUM < 90600
@@ -756,6 +762,8 @@ FinishForeignModify(PxfFdwModifyState *pxfmstate)
 
 	EndCopyFrom(pxfmstate->cstate);
 	pxfmstate->cstate = NULL;
+	PxfBridgeCleanup(pxfmstate);
+
 }
 
 /*
@@ -781,7 +789,9 @@ InitCopyState(PxfFdwScanState *pxfsstate)
 {
 	CopyState	cstate;
 
+	MemoryContext oldcontext = MemoryContextSwitchTo(CurTransactionContext);
 	PxfBridgeImportStart(pxfsstate);
+	MemoryContextSwitchTo(oldcontext);
 
 	/*
 	 * Create CopyState from FDW options.  We always acquire all columns, so
@@ -861,7 +871,9 @@ InitCopyStateForModify(PxfFdwModifyState *pxfmstate)
 
 	copy_options = pxfmstate->options->copy_options;
 
+	MemoryContext oldcontext = MemoryContextSwitchTo(CurTransactionContext);
 	PxfBridgeExportStart(pxfmstate);
+	MemoryContextSwitchTo(oldcontext);
 
 	/*
 	 * Create CopyState from FDW options.  We always acquire all columns to match the expected ScanTupleSlot signature.

--- a/fdw/pxf_fdw.c
+++ b/fdw/pxf_fdw.c
@@ -427,7 +427,7 @@ pxfBeginForeignScan(ForeignScanState *node, int eflags)
 	 * Save state in node->fdw_state.  We must save enough information to call
 	 * BeginCopyFrom() again.
 	 */
-	pxfsstate = palloc0(sizeof(PxfFdwScanState));
+	pxfsstate = palloc(sizeof(PxfFdwScanState));
 	initStringInfo(&pxfsstate->uri);
 
 	pxfsstate->filter_str = filter_str;


### PR DESCRIPTION
Canceling read requests in the PXF service

In case of any errors, including request cancellation, the patch
15676e2 closes curl connections to the PXF connector.
However, for read requests, the PXF connector
is not notified of this event because it is waiting for blocked I/O.
For example, it waits for a remote JDBC request to complete.
This wastes resources on the PXF connector and on the remote side
because the query results are no longer needed.

This patch enhances the functionality of the PXF protocol in clearing
the execution context when a read request fails. In this case, it calls
the POST /pxf/cancel endpoint on the PXF connector with the same
headers as the main request, adding a header with the client port
and 1 second timeout.

For some PXF structures that are used in the callback,
it was necessary to add their allocation in the memory context
of the current transaction, because otherwise the memory for
them was freed before the callback was called.

This patch works with the Java part of the patch fbfff8c.

For example, this may happen when a request is canceled when an exclusive lock has been taken on a table referenced by an external table or fdw.
1) create external table
```sql
CREATE EXTENSION pxf;
CREATE TABLE t(a int) DISTRIBUTED BY (a);
INSERT INTO t SELECT i FROM generate_series(1, 1000) i;
CREATE EXTERNAL TABLE e(a int) LOCATION('pxf://t?PROFILE=JDBC&JDBC_DRIVER=org.postgresql.Driver&DB_URL=jdbc:postgresql://localhost:6432/postgres') FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
```
or create fdw
```sql
CREATE EXTENSION pxf_fdw;
CREATE TABLE t(a int) DISTRIBUTED BY (a);
INSERT INTO t SELECT i FROM generate_series(1, 1000) i;
CREATE SERVER s FOREIGN DATA WRAPPER jdbc_pxf_fdw OPTIONS (jdbc_driver 'org.postgresql.Driver', db_url 'jdbc:postgresql://localhost:6432/postgres');
CREATE USER MAPPING FOR CURRENT_USER SERVER s;
CREATE FOREIGN TABLE e (a int) SERVER s OPTIONS (resource 't');
```
2) in one session, run the command:
```sql
begin;lock table t in ACCESS exclusive mode;
```
and don't close the session.

3) in another session, run the command:
```sql
SELECT count(*) FROM e;
```
and then interrupt its execution with Ctrl+C, but don't close the session.
The connection from the Java-part to the C-part remains:
```sh
bash-4.2$ netstat -enpt | grep :5888
tcp        1      0 127.0.0.1:5888          127.0.0.1:51266         CLOSE_WAIT  1000       605440     75523/java          
```
expected (and with patch): all connections are closed
```sh
bash-4.2$ netstat -enpt | grep :5888
```