### PR TITLE
ADBDEV-4490: Add resource release callback to pxf external tables and fdw

### DIFF
--- a/external-table/src/libchurl.c
+++ b/external-table/src/libchurl.c
@@ -23,6 +23,7 @@
 #include "utils/fmgroids.h"
 #include "utils/guc.h"
 #include "utils/jsonapi.h"
+#include "utils/resowner.h"
 
 /* include libcurl without typecheck.
  * This allows wrapping curl_easy_setopt to be wrapped
@@ -82,6 +83,8 @@ typedef struct
 
 	/* true on upload, false on download */
 	bool		upload;
+
+	ResourceOwner owner;
 } churl_context;
 
 /*
@@ -90,6 +93,8 @@ typedef struct
 typedef struct
 {
 	struct curl_slist *headers;
+
+	ResourceOwner owner;
 } churl_settings;
 
 /* the null action object used for pure validation */
@@ -130,11 +135,33 @@ static char	   *get_http_error_msg(long http_ret_code, char *msg, char *curl_err
 static char	   *build_header_str(const char *format, const char *key, const char *value);
 static bool	IsValidJson(text *json);
 
+static void
+churl_headers_abort_callback(ResourceReleasePhase phase,
+						bool isCommit,
+						bool isTopLevel,
+						void *arg)
+{
+	churl_settings *settings = arg;
+
+	if (phase != RESOURCE_RELEASE_AFTER_LOCKS)
+		return;
+
+	if (settings->owner == CurrentResourceOwner)
+	{
+		if (isCommit)
+			elog(LOG, "pxf churl_headers reference leak: %p still referenced", arg);
+
+		churl_headers_cleanup(settings);
+	}
+}
 
 CHURL_HEADERS
 churl_headers_init(void)
 {
 	churl_settings *settings = (churl_settings *) palloc0(sizeof(churl_settings));
+
+	settings->owner = CurrentResourceOwner;
+	RegisterResourceReleaseCallback(churl_headers_abort_callback, settings);
 
 	return (CHURL_HEADERS) settings;
 }
@@ -304,6 +331,8 @@ churl_headers_cleanup(CHURL_HEADERS headers)
 
 	if (!settings)
 		return;
+
+	UnregisterResourceReleaseCallback(churl_headers_abort_callback, settings);
 
 	if (settings->headers)
 		curl_slist_free_all(settings->headers);
@@ -528,10 +557,33 @@ churl_cleanup(CHURL_HANDLE handle, bool after_error)
 	churl_cleanup_context(context);
 }
 
+static void
+churl_context_abort_callback(ResourceReleasePhase phase,
+						bool isCommit,
+						bool isTopLevel,
+						void *arg)
+{
+	churl_context *context = arg;
+
+	if (phase != RESOURCE_RELEASE_AFTER_LOCKS)
+		return;
+
+	if (context->owner == CurrentResourceOwner)
+	{
+		if (isCommit)
+			elog(LOG, "pxf churl_context reference leak: %p still referenced", arg);
+
+		cleanup_curl_handle(context);
+	}
+}
+
 churl_context *
 churl_new_context()
 {
 	churl_context *context = palloc0(sizeof(churl_context));
+
+	context->owner = CurrentResourceOwner;
+	RegisterResourceReleaseCallback(churl_context_abort_callback, context);
 
 	return context;
 }
@@ -709,6 +761,7 @@ finish_upload(churl_context *context)
 static void
 cleanup_curl_handle(churl_context *context)
 {
+	UnregisterResourceReleaseCallback(churl_context_abort_callback, context);
 	if (!context->curl_handle)
 		return;
 	if (context->multi_handle)

--- a/fdw/libchurl.c
+++ b/fdw/libchurl.c
@@ -29,6 +29,8 @@
 #include "utils/fmgroids.h"
 #include "utils/guc.h"
 #include "utils/jsonapi.h"
+#include "utils/memutils.h"
+#include "utils/resowner.h"
 
 /* include libcurl without typecheck.
  * This allows wrapping curl_easy_setopt to be wrapped
@@ -88,6 +90,8 @@ typedef struct churl_handle
 
 	/* true on upload, false on download */
 	bool		upload;
+
+	ResourceOwner owner;
 } churl_context;
 
 /*
@@ -96,6 +100,8 @@ typedef struct churl_handle
 typedef struct churl_settings
 {
 	struct curl_slist *headers;
+
+	ResourceOwner owner;
 } churl_settings;
 
 /* the null action object used for pure validation */
@@ -136,11 +142,35 @@ static char	   *get_http_error_msg(long http_ret_code, char *msg, char *curl_err
 static char	   *build_header_str(const char *format, const char *key, const char *value);
 static bool		IsValidJson(text *json);
 
+static void
+churl_headers_abort_callback(ResourceReleasePhase phase,
+						bool isCommit,
+						bool isTopLevel,
+						void *arg)
+{
+	churl_settings *settings = arg;
+
+	if (phase != RESOURCE_RELEASE_AFTER_LOCKS)
+		return;
+
+	if (settings->owner == CurrentResourceOwner)
+	{
+		if (isCommit)
+			elog(LOG, "pxf churl_headers reference leak: %p still referenced", arg);
+
+		churl_headers_cleanup(settings);
+	}
+}
 
 CHURL_HEADERS
 churl_headers_init(void)
 {
+	MemoryContext oldcontext = MemoryContextSwitchTo(CurTransactionContext);
 	churl_settings *settings = (churl_settings *) palloc0(sizeof(churl_settings));
+	MemoryContextSwitchTo(oldcontext);
+
+	settings->owner = CurrentResourceOwner;
+	RegisterResourceReleaseCallback(churl_headers_abort_callback, settings);
 
 	return (CHURL_HEADERS) settings;
 }
@@ -310,6 +340,8 @@ churl_headers_cleanup(CHURL_HEADERS headers)
 
 	if (!settings)
 		return;
+
+	UnregisterResourceReleaseCallback(churl_headers_abort_callback, settings);
 
 	if (settings->headers)
 		curl_slist_free_all(settings->headers);
@@ -535,10 +567,35 @@ churl_cleanup(CHURL_HANDLE handle, bool after_error)
 	churl_cleanup_context(context);
 }
 
+static void
+churl_context_abort_callback(ResourceReleasePhase phase,
+						bool isCommit,
+						bool isTopLevel,
+						void *arg)
+{
+	churl_context *context = arg;
+
+	if (phase != RESOURCE_RELEASE_AFTER_LOCKS)
+		return;
+
+	if (context->owner == CurrentResourceOwner)
+	{
+		if (isCommit)
+			elog(LOG, "pxf churl_context reference leak: %p still referenced", arg);
+
+		cleanup_curl_handle(context);
+	}
+}
+
 churl_context *
 churl_new_context()
 {
+	MemoryContext oldcontext = MemoryContextSwitchTo(CurTransactionContext);
 	churl_context *context = palloc0(sizeof(churl_context));
+	MemoryContextSwitchTo(oldcontext);
+
+	context->owner = CurrentResourceOwner;
+	RegisterResourceReleaseCallback(churl_context_abort_callback, context);
 
 	return context;
 }
@@ -717,6 +774,7 @@ finish_upload(churl_context *context)
 static void
 cleanup_curl_handle(churl_context *context)
 {
+	UnregisterResourceReleaseCallback(churl_context_abort_callback, context);
 	if (!context->curl_handle)
 		return;
 	if (context->multi_handle)


### PR DESCRIPTION
Add resource release callback to pxf external tables and fdw

The C-part of the PXF external table releases the context
(cleanup_context -> gpbridge_cleanup) only on the last call
in the pxfprotocol_export and pxfprotocol_import functions.
The C-part of the PXF FDW releases the context (PxfBridgeCleanup)
only in the FinishForeignModify function.
That is, on errors, the context is not released, including
curl-connections to the Java-part are not closed.
Therefore, I added a callback to release resources on errors,
which releases the context, including closing curl-connections.
For some PXF FDW structures that are used in the callback,
it was necessary to add their allocation in the memory context
of the current transaction, because otherwise the memory for
them was freed before the callback was called.

For example, this may happen when a request is canceled when an exclusive lock has been taken on a table referenced by an external table or fdw.
1) create external table
```sql
CREATE EXTENSION pxf;
CREATE TABLE t(a int) DISTRIBUTED BY (a);
INSERT INTO t SELECT i FROM generate_series(1, 1000) i;
CREATE EXTERNAL TABLE e(a int) LOCATION('pxf://t?PROFILE=JDBC&JDBC_DRIVER=org.postgresql.Driver&DB_URL=jdbc:postgresql://localhost:6432/postgres') FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
```
or create fdw
```sql
CREATE EXTENSION pxf_fdw;
CREATE TABLE t(a int) DISTRIBUTED BY (a);
INSERT INTO t SELECT i FROM generate_series(1, 1000) i;
CREATE SERVER s FOREIGN DATA WRAPPER jdbc_pxf_fdw OPTIONS (jdbc_driver 'org.postgresql.Driver', db_url 'jdbc:postgresql://localhost:6432/postgres');
CREATE USER MAPPING FOR CURRENT_USER SERVER s;
CREATE FOREIGN TABLE e (a int) SERVER s OPTIONS (resource 't');
```
2) in one session, run the command:
```sql
begin;lock table t in ACCESS exclusive mode;
```
and don't close the session.

3) in another session, run the command:
```sql
SELECT count(*) FROM e;
```
and then interrupt its execution with Ctrl+C, but don't close the session.
The connection from the C-part to the Java-part remains:
```sh
bash-4.2$ netstat -enpt | grep :5888
tcp        0      0 127.0.0.1:42236         127.0.0.1:5888          ESTABLISHED 1000       7244695    161781/postgres:  6 
tcp        0      0 127.0.0.1:5888          127.0.0.1:42236         ESTABLISHED 1000       7229437    157250/java         
```
expected (and with patch): adb connection is closed, but Java-part remain:
```sh
bash-4.2$ netstat -enpt | grep :5888
tcp        1      0 127.0.0.1:5888          127.0.0.1:47074         CLOSE_WAIT  1000       6885317    144206/java         
```