### PR TITLE
ADBDEV-4490-hard: Add resource release callback to pxf external tables and fdw

### DIFF
--- a/external-table/src/pxfbridge.h
+++ b/external-table/src/pxfbridge.h
@@ -43,6 +43,9 @@ typedef struct
 	ProjectionInfo *proj_info;
 	List           *quals;
 	bool           completed;
+	bool           after_error;
+	bool           upload;
+	ResourceOwner  owner;
 } gphadoop_context;
 
 /*

--- a/fdw/pxf_bridge.h
+++ b/fdw/pxf_bridge.h
@@ -53,6 +53,8 @@ typedef struct PxfFdwScanState
 	PxfOptions *options;
 	CopyState	cstate;
 	ProjectionInfo *projectionInfo;
+	bool		after_error;
+	ResourceOwner owner;
 } PxfFdwScanState;
 
 /*
@@ -72,10 +74,13 @@ typedef struct PxfFdwModifyState
 	Datum	   *values;			/* List of values exported for the row */
 	bool	   *nulls;			/* List of null fields for the exported row */
 #endif
+	bool		after_error;
+	ResourceOwner owner;
 } PxfFdwModifyState;
 
 /* Clean up churl related data structures from the context */
 void		PxfBridgeCleanup(PxfFdwModifyState *context);
+void		PxfBridgeImportCleanup(PxfFdwScanState *pxfsstate);
 
 /* Sets up data before starting import */
 void		PxfBridgeImportStart(PxfFdwScanState *pxfsstate);


### PR DESCRIPTION
Add resource release callback to pxf external tables and fdw

The C-part of the PXF external table releases the context
(cleanup_context -> gpbridge_cleanup) only on the last call
in the pxfprotocol_export and pxfprotocol_import functions.
The C-part of the PXF FDW releases the context (PxfBridgeCleanup)
only in the FinishForeignModify function.
That is, on errors, the context is not released, including
curl-connections to the Java-part are not closed.
Therefore, I added a callback to release resources on errors,
which releases the context, including closing curl-connections.
For some PXF FDW structures that are used in the callback,
it was necessary to add their allocation in the memory context
of the current transaction, because otherwise the memory for
them was freed before the callback was called.

For example, this may happen when a request is canceled when an exclusive lock has been taken on a table referenced by an external table or fdw.
1) create external table
```sql
CREATE EXTENSION pxf;
CREATE TABLE t(a int) DISTRIBUTED BY (a);
INSERT INTO t SELECT i FROM generate_series(1, 1000) i;
CREATE EXTERNAL TABLE e(a int) LOCATION('pxf://t?PROFILE=JDBC&JDBC_DRIVER=org.postgresql.Driver&DB_URL=jdbc:postgresql://localhost:6432/postgres') FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
```
or create fdw
```sql
CREATE EXTENSION pxf_fdw;
CREATE TABLE t(a int) DISTRIBUTED BY (a);
INSERT INTO t SELECT i FROM generate_series(1, 1000) i;
CREATE SERVER s FOREIGN DATA WRAPPER jdbc_pxf_fdw OPTIONS (jdbc_driver 'org.postgresql.Driver', db_url 'jdbc:postgresql://localhost:6432/postgres');
CREATE USER MAPPING FOR CURRENT_USER SERVER s;
CREATE FOREIGN TABLE e (a int) SERVER s OPTIONS (resource 't');
```
2) in one session, run the command:
```sql
begin;lock table t in ACCESS exclusive mode;
```
and don't close the session.

3) in another session, run the command:
```sql
SELECT count(*) FROM e;
```
and then interrupt its execution with Ctrl+C, but don't close the session.
The connection from the C-part to the Java-part remains:
```sh
bash-4.2$ netstat -enpt | grep :5888
tcp        0      0 127.0.0.1:42236         127.0.0.1:5888          ESTABLISHED 1000       7244695    161781/postgres:  6 
tcp        0      0 127.0.0.1:5888          127.0.0.1:42236         ESTABLISHED 1000       7229437    157250/java         
```
expected (and with patch): adb connection is closed, but Java-part remain:
```sh
bash-4.2$ netstat -enpt | grep :5888
tcp        1      0 127.0.0.1:5888          127.0.0.1:47074         CLOSE_WAIT  1000       6885317    144206/java         
```