### PR TITLE
ADBDEV-4253-hard: Canceling read requests in the PXF service

### DIFF
--- a/external-table/src/libchurl.c
+++ b/external-table/src/libchurl.c
@@ -389,7 +389,7 @@ churl_init(const char *url, CHURL_HEADERS headers)
 }
 
 CHURL_HANDLE
-churl_init_upload(const char *url, CHURL_HEADERS headers)
+churl_init_upload_timeout(const char *url, CHURL_HEADERS headers, long timeout)
 {
 	churl_context *context = churl_init(url, headers);
 
@@ -398,12 +398,19 @@ churl_init_upload(const char *url, CHURL_HEADERS headers)
 	set_curl_option(context, CURLOPT_POST, (const void *) true);
 	set_curl_option(context, CURLOPT_READFUNCTION, read_callback);
 	set_curl_option(context, CURLOPT_READDATA, context);
+	set_curl_option(context, CURLOPT_TIMEOUT, (const void *) timeout);
 	churl_headers_append(headers, "Content-Type", "application/octet-stream");
 	churl_headers_append(headers, "Transfer-Encoding", "chunked");
 	churl_headers_append(headers, "Expect", "100-continue");
 
 	setup_multi_handle(context);
 	return (CHURL_HANDLE) context;
+}
+
+CHURL_HANDLE
+churl_init_upload(const char *url, CHURL_HEADERS headers)
+{
+	return churl_init_upload_timeout(url, headers, 0);
 }
 
 CHURL_HANDLE
@@ -414,6 +421,16 @@ churl_init_download(const char *url, CHURL_HEADERS headers)
 	context->upload = false;
 
 	setup_multi_handle(context);
+
+	int curl_error;
+	long local_port;
+
+	if (CURLE_OK != (curl_error = curl_easy_getinfo(context->curl_handle, CURLINFO_LOCAL_PORT, &local_port)))
+		elog(ERROR, "internal error: curl_easy_getinfo failed(%d - %s)",
+			curl_error, curl_easy_strerror(curl_error));
+
+	churl_headers_append(headers, "X-GP-CLIENT-PORT", psprintf("%li", local_port));
+
 	return (CHURL_HANDLE) context;
 }
 

--- a/external-table/src/libchurl.h
+++ b/external-table/src/libchurl.h
@@ -105,6 +105,7 @@ void		churl_headers_cleanup(CHURL_HEADERS headers);
  * returns a handle to churl transfer
  */
 CHURL_HANDLE churl_init_upload(const char *url, CHURL_HEADERS headers);
+CHURL_HANDLE churl_init_upload_timeout(const char *url, CHURL_HEADERS headers, long timeout);
 
 /*
  * Start a download to url

--- a/fdw/libchurl.h
+++ b/fdw/libchurl.h
@@ -105,6 +105,7 @@ void		churl_headers_cleanup(CHURL_HEADERS headers);
  * returns a handle to churl transfer
  */
 CHURL_HANDLE churl_init_upload(const char *url, CHURL_HEADERS headers);
+CHURL_HANDLE churl_init_upload_timeout(const char *url, CHURL_HEADERS headers, long timeout);
 
 /*
  * Start a download to url


### PR DESCRIPTION
Canceling read requests in the PXF service

In case of any errors, including request cancellation, the patch
2fd4adc closes curl connections to the PXF connector.
However, for read requests, the PXF connector
is not notified of this event because it is waiting for blocked I/O.
For example, it waits for a remote JDBC request to complete.
This wastes resources on the PXF connector and on the remote side
because the query results are no longer needed.

This patch enhances the functionality of the PXF protocol in clearing
the execution context when a read request fails. In this case, it calls
the POST /pxf/cancel endpoint on the PXF connector with the same headers
as the main request, adding a header with the client port.

This patch works with the Java part of the patch fbfff8c.