### PR TITLE
ADBDEV-4490: Add resource release callback to pxf external tables and fdw

### DIFF
--- a/external-table/src/libchurl.c
+++ b/external-table/src/libchurl.c
@@ -23,6 +23,7 @@
 #include "utils/fmgroids.h"
 #include "utils/guc.h"
 #include "utils/jsonapi.h"
+#include "utils/memutils.h"
 #include "utils/resowner.h"
 
 /* include libcurl without typecheck.
@@ -158,7 +159,9 @@ churl_headers_abort_callback(ResourceReleasePhase phase,
 CHURL_HEADERS
 churl_headers_init(void)
 {
+	MemoryContext oldcontext = MemoryContextSwitchTo(CurTransactionContext);
 	churl_settings *settings = (churl_settings *) palloc0(sizeof(churl_settings));
+	MemoryContextSwitchTo(oldcontext);
 
 	settings->owner = CurrentResourceOwner;
 	RegisterResourceReleaseCallback(churl_headers_abort_callback, settings);
@@ -582,7 +585,9 @@ churl_context_abort_callback(ResourceReleasePhase phase,
 churl_context *
 churl_new_context()
 {
+	MemoryContext oldcontext = MemoryContextSwitchTo(CurTransactionContext);
 	churl_context *context = palloc0(sizeof(churl_context));
+	MemoryContextSwitchTo(oldcontext);
 
 	context->owner = CurrentResourceOwner;
 	RegisterResourceReleaseCallback(churl_context_abort_callback, context);

--- a/external-table/src/libchurl.c
+++ b/external-table/src/libchurl.c
@@ -23,6 +23,7 @@
 #include "utils/fmgroids.h"
 #include "utils/guc.h"
 #include "utils/jsonapi.h"
+#include "utils/resowner.h"
 
 /* include libcurl without typecheck.
  * This allows wrapping curl_easy_setopt to be wrapped
@@ -82,6 +83,8 @@ typedef struct
 
 	/* true on upload, false on download */
 	bool		upload;
+
+	ResourceOwner owner;
 } churl_context;
 
 /*
@@ -90,6 +93,8 @@ typedef struct
 typedef struct
 {
 	struct curl_slist *headers;
+
+	ResourceOwner owner;
 } churl_settings;
 
 /* the null action object used for pure validation */
@@ -130,11 +135,33 @@ static char	   *get_http_error_msg(long http_ret_code, char *msg, char *curl_err
 static char	   *build_header_str(const char *format, const char *key, const char *value);
 static bool	IsValidJson(text *json);
 
+static void
+churl_headers_abort_callback(ResourceReleasePhase phase,
+						bool isCommit,
+						bool isTopLevel,
+						void *arg)
+{
+	churl_settings *settings = arg;
+
+	if (phase != RESOURCE_RELEASE_AFTER_LOCKS)
+		return;
+
+	if (settings->owner == CurrentResourceOwner)
+	{
+		if (isCommit)
+			elog(LOG, "pxf churl_headers reference leak: %p still referenced", arg);
+
+		churl_headers_cleanup(settings);
+	}
+}
 
 CHURL_HEADERS
 churl_headers_init(void)
 {
 	churl_settings *settings = (churl_settings *) palloc0(sizeof(churl_settings));
+
+	settings->owner = CurrentResourceOwner;
+	RegisterResourceReleaseCallback(churl_headers_abort_callback, settings);
 
 	return (CHURL_HEADERS) settings;
 }
@@ -304,6 +331,8 @@ churl_headers_cleanup(CHURL_HEADERS headers)
 
 	if (!settings)
 		return;
+
+	UnregisterResourceReleaseCallback(churl_headers_abort_callback, settings);
 
 	if (settings->headers)
 		curl_slist_free_all(settings->headers);
@@ -530,10 +559,33 @@ churl_cleanup(CHURL_HANDLE handle, bool after_error)
 	churl_cleanup_context(context);
 }
 
+static void
+churl_context_abort_callback(ResourceReleasePhase phase,
+						bool isCommit,
+						bool isTopLevel,
+						void *arg)
+{
+	churl_context *context = arg;
+
+	if (phase != RESOURCE_RELEASE_AFTER_LOCKS)
+		return;
+
+	if (context->owner == CurrentResourceOwner)
+	{
+		if (isCommit)
+			elog(LOG, "pxf churl_context reference leak: %p still referenced", arg);
+
+		cleanup_curl_handle(context);
+	}
+}
+
 churl_context *
 churl_new_context()
 {
 	churl_context *context = palloc0(sizeof(churl_context));
+
+	context->owner = CurrentResourceOwner;
+	RegisterResourceReleaseCallback(churl_context_abort_callback, context);
 
 	context->download_buffer = palloc0(sizeof(churl_buffer));
 	context->upload_buffer = palloc0(sizeof(churl_buffer));
@@ -713,6 +765,7 @@ finish_upload(churl_context *context)
 static void
 cleanup_curl_handle(churl_context *context)
 {
+	UnregisterResourceReleaseCallback(churl_context_abort_callback, context);
 	if (!context->curl_handle)
 		return;
 	if (context->multi_handle)

--- a/external-table/src/libchurl.c
+++ b/external-table/src/libchurl.c
@@ -163,7 +163,7 @@ churl_headers_init(void)
 	churl_settings *settings = (churl_settings *) palloc0(sizeof(churl_settings));
 	MemoryContextSwitchTo(oldcontext);
 
-	settings->owner = CurrentResourceOwner;
+	settings->owner = CurTransactionResourceOwner;
 	RegisterResourceReleaseCallback(churl_headers_abort_callback, settings);
 
 	return (CHURL_HEADERS) settings;
@@ -589,7 +589,7 @@ churl_new_context()
 	churl_context *context = palloc0(sizeof(churl_context));
 	MemoryContextSwitchTo(oldcontext);
 
-	context->owner = CurrentResourceOwner;
+	context->owner = CurTransactionResourceOwner;
 	RegisterResourceReleaseCallback(churl_context_abort_callback, context);
 
 	context->download_buffer = palloc0(sizeof(churl_buffer));

--- a/fdw/libchurl.c
+++ b/fdw/libchurl.c
@@ -29,6 +29,8 @@
 #include "utils/fmgroids.h"
 #include "utils/guc.h"
 #include "utils/jsonapi.h"
+#include "utils/memutils.h"
+#include "utils/resowner.h"
 
 /* include libcurl without typecheck.
  * This allows wrapping curl_easy_setopt to be wrapped
@@ -88,6 +90,8 @@ typedef struct churl_handle
 
 	/* true on upload, false on download */
 	bool		upload;
+
+	ResourceOwner owner;
 } churl_context;
 
 /*
@@ -96,6 +100,8 @@ typedef struct churl_handle
 typedef struct churl_settings
 {
 	struct curl_slist *headers;
+
+	ResourceOwner owner;
 } churl_settings;
 
 /* the null action object used for pure validation */
@@ -136,11 +142,35 @@ static char	   *get_http_error_msg(long http_ret_code, char *msg, char *curl_err
 static char	   *build_header_str(const char *format, const char *key, const char *value);
 static bool		IsValidJson(text *json);
 
+static void
+churl_headers_abort_callback(ResourceReleasePhase phase,
+						bool isCommit,
+						bool isTopLevel,
+						void *arg)
+{
+	churl_settings *settings = arg;
+
+	if (phase != RESOURCE_RELEASE_AFTER_LOCKS)
+		return;
+
+	if (settings->owner == CurrentResourceOwner)
+	{
+		if (isCommit)
+			elog(LOG, "pxf churl_headers reference leak: %p still referenced", arg);
+
+		churl_headers_cleanup(settings);
+	}
+}
 
 CHURL_HEADERS
 churl_headers_init(void)
 {
+	MemoryContext oldcontext = MemoryContextSwitchTo(CurTransactionContext);
 	churl_settings *settings = (churl_settings *) palloc0(sizeof(churl_settings));
+	MemoryContextSwitchTo(oldcontext);
+
+	settings->owner = CurrentResourceOwner;
+	RegisterResourceReleaseCallback(churl_headers_abort_callback, settings);
 
 	return (CHURL_HEADERS) settings;
 }
@@ -310,6 +340,8 @@ churl_headers_cleanup(CHURL_HEADERS headers)
 
 	if (!settings)
 		return;
+
+	UnregisterResourceReleaseCallback(churl_headers_abort_callback, settings);
 
 	if (settings->headers)
 		curl_slist_free_all(settings->headers);
@@ -537,10 +569,35 @@ churl_cleanup(CHURL_HANDLE handle, bool after_error)
 	churl_cleanup_context(context);
 }
 
+static void
+churl_context_abort_callback(ResourceReleasePhase phase,
+						bool isCommit,
+						bool isTopLevel,
+						void *arg)
+{
+	churl_context *context = arg;
+
+	if (phase != RESOURCE_RELEASE_AFTER_LOCKS)
+		return;
+
+	if (context->owner == CurrentResourceOwner)
+	{
+		if (isCommit)
+			elog(LOG, "pxf churl_context reference leak: %p still referenced", arg);
+
+		cleanup_curl_handle(context);
+	}
+}
+
 churl_context *
 churl_new_context()
 {
+	MemoryContext oldcontext = MemoryContextSwitchTo(CurTransactionContext);
 	churl_context *context = palloc0(sizeof(churl_context));
+	MemoryContextSwitchTo(oldcontext);
+
+	context->owner = CurrentResourceOwner;
+	RegisterResourceReleaseCallback(churl_context_abort_callback, context);
 
 	context->download_buffer = palloc0(sizeof(churl_buffer));
 	context->upload_buffer = palloc0(sizeof(churl_buffer));
@@ -723,6 +780,7 @@ finish_upload(churl_context *context)
 static void
 cleanup_curl_handle(churl_context *context)
 {
+	UnregisterResourceReleaseCallback(churl_context_abort_callback, context);
 	if (!context->curl_handle)
 		return;
 	if (context->multi_handle)

--- a/fdw/libchurl.c
+++ b/fdw/libchurl.c
@@ -169,7 +169,7 @@ churl_headers_init(void)
 	churl_settings *settings = (churl_settings *) palloc0(sizeof(churl_settings));
 	MemoryContextSwitchTo(oldcontext);
 
-	settings->owner = CurrentResourceOwner;
+	settings->owner = CurTransactionResourceOwner;
 	RegisterResourceReleaseCallback(churl_headers_abort_callback, settings);
 
 	return (CHURL_HEADERS) settings;
@@ -596,7 +596,7 @@ churl_new_context()
 	churl_context *context = palloc0(sizeof(churl_context));
 	MemoryContextSwitchTo(oldcontext);
 
-	context->owner = CurrentResourceOwner;
+	context->owner = CurTransactionResourceOwner;
 	RegisterResourceReleaseCallback(churl_context_abort_callback, context);
 
 	context->download_buffer = palloc0(sizeof(churl_buffer));

--- a/fdw/pxf_bridge.c
+++ b/fdw/pxf_bridge.c
@@ -34,6 +34,32 @@ static size_t FillBuffer(PxfFdwScanState *pxfsstate, char *start, size_t size);
 #endif
 
 /*
+ * Clean up churl related data structures from the PXF FDW scan state.
+ */
+void
+PxfBridgeImportCleanup(PxfFdwScanState *pxfsstate)
+{
+	if (pxfsstate == NULL)
+		return;
+
+	churl_cleanup(pxfsstate->churl_handle, false);
+	pxfsstate->churl_handle = NULL;
+
+	churl_headers_cleanup(pxfsstate->churl_headers);
+	pxfsstate->churl_headers = NULL;
+
+	if (pxfsstate->uri.data)
+	{
+		pfree(pxfsstate->uri.data);
+	}
+
+	if (pxfsstate->options)
+	{
+		pfree(pxfsstate->options);
+	}
+}
+
+/*
  * Clean up churl related data structures from the PXF FDW modify state.
  */
 void

--- a/fdw/pxf_bridge.h
+++ b/fdw/pxf_bridge.h
@@ -75,6 +75,7 @@ typedef struct PxfFdwModifyState
 } PxfFdwModifyState;
 
 /* Clean up churl related data structures from the context */
+void		PxfBridgeImportCleanup(PxfFdwScanState *pxfsstate);
 void		PxfBridgeCleanup(PxfFdwModifyState *context);
 
 /* Sets up data before starting import */

--- a/fdw/pxf_fdw.c
+++ b/fdw/pxf_fdw.c
@@ -568,6 +568,7 @@ pxfEndForeignScan(ForeignScanState *node)
 	if (pxfsstate)
 		EndCopyFrom(pxfsstate->cstate);
 
+	PxfBridgeImportCleanup(pxfsstate);
 	elog(DEBUG5, "pxf_fdw: pxfEndForeignScan ends on segment: %d", PXF_SEGMENT_ID);
 }
 


### PR DESCRIPTION
Add resource release callback to pxf external tables and fdw

The C-part of the PXF external table releases the context
(cleanup_context -> gpbridge_cleanup) only on the last call
in the pxfprotocol_export and pxfprotocol_import functions.
The C-part of the PXF FDW releases the context (PxfBridgeCleanup)
only for write requests in the FinishForeignModify function.
That is, on errors (and in PXF FDW and for successful read requests),
the context is not released, including
curl-connections to the Java-part are not closed.

Therefore, I added a callback to release resources on errors,
which releases the context, including closing curl-connections.

For some PXF structures that are used in the callback,
it was necessary to add their allocation in the memory context
of the current transaction, because otherwise the memory for
them was freed before the callback was called.

For example, this may happen when a request is canceled when an exclusive lock has been taken on a table referenced by an external table or fdw.
1) create external table
```sql
CREATE EXTENSION pxf;
CREATE TABLE t(a int) DISTRIBUTED BY (a);
INSERT INTO t SELECT i FROM generate_series(1, 1000) i;
CREATE EXTERNAL TABLE e(a int) LOCATION('pxf://t?PROFILE=JDBC&JDBC_DRIVER=org.postgresql.Driver&DB_URL=jdbc:postgresql://localhost:6432/postgres') FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
```
or create fdw
```sql
CREATE EXTENSION pxf_fdw;
CREATE TABLE t(a int) DISTRIBUTED BY (a);
INSERT INTO t SELECT i FROM generate_series(1, 1000) i;
CREATE SERVER s FOREIGN DATA WRAPPER jdbc_pxf_fdw OPTIONS (jdbc_driver 'org.postgresql.Driver', db_url 'jdbc:postgresql://localhost:6432/postgres');
CREATE USER MAPPING FOR CURRENT_USER SERVER s;
CREATE FOREIGN TABLE e (a int) SERVER s OPTIONS (resource 't');
```
2) in one session, run the command:
```sql
begin;lock table t in ACCESS exclusive mode;
```
and don't close the session.

3) in another session, run the command:
```sql
SELECT count(*) FROM e;
```
and then interrupt its execution with Ctrl+C, but don't close the session.
The connection from the C-part to the Java-part remains:
```sh
bash-4.2$ netstat -enpt | grep :5888
tcp        0      0 127.0.0.1:5888          127.0.0.1:51266         ESTABLISHED 1000       605440     75523/java          
tcp        0      0 127.0.0.1:51266         127.0.0.1:5888          ESTABLISHED 1000       594918     76003/postgres:  64 
```
expected (and with patch): ADB connection is closed, but Java-part remain:
```sh
bash-4.2$ netstat -enpt | grep :5888
tcp        1      0 127.0.0.1:5888          127.0.0.1:51266         CLOSE_WAIT  1000       605440     75523/java          
```