### PR TITLE
ADBDEV-4556: Reapply patch replacing multiple check_reponse usage

### DIFF
--- a/external-table/src/libchurl.c
+++ b/external-table/src/libchurl.c
@@ -505,7 +505,6 @@ churl_read_check_connectivity(CHURL_HANDLE handle)
 	Assert(!context->upload);
 
 	fill_internal_buffer(context, 1);
-	check_response(context);
 }
 
 /*
@@ -683,6 +682,8 @@ multi_perform(churl_context *context)
 	if (curl_error != CURLM_OK)
 		elog(ERROR, "internal error: curl_multi_perform failed (%d - %s)",
 			 curl_error, curl_easy_strerror(curl_error));
+
+	check_response(context);
 }
 
 static bool
@@ -709,8 +710,6 @@ flush_internal_buffer(churl_context *context)
 
 		multi_perform(context);
 	}
-
-	check_response(context);
 
 	if ((context->curl_still_running == 0) &&
 		((context_buffer->top - context_buffer->bot) > 0))
@@ -766,8 +765,6 @@ finish_upload(churl_context *context)
 	 */
 	while (context->curl_still_running != 0)
 		multi_perform(context);
-
-	check_response(context);
 }
 
 static void

--- a/external-table/src/libchurl.c
+++ b/external-table/src/libchurl.c
@@ -505,6 +505,7 @@ churl_read_check_connectivity(CHURL_HANDLE handle)
 	Assert(!context->upload);
 
 	fill_internal_buffer(context, 1);
+	check_response(context);
 }
 
 /*
@@ -682,8 +683,6 @@ multi_perform(churl_context *context)
 	if (curl_error != CURLM_OK)
 		elog(ERROR, "internal error: curl_multi_perform failed (%d - %s)",
 			 curl_error, curl_easy_strerror(curl_error));
-
-	check_response(context);
 }
 
 static bool
@@ -710,6 +709,8 @@ flush_internal_buffer(churl_context *context)
 
 		multi_perform(context);
 	}
+
+	check_response(context);
 
 	if ((context->curl_still_running == 0) &&
 		((context_buffer->top - context_buffer->bot) > 0))
@@ -765,6 +766,8 @@ finish_upload(churl_context *context)
 	 */
 	while (context->curl_still_running != 0)
 		multi_perform(context);
+
+	check_response(context);
 }
 
 static void

--- a/fdw/libchurl.c
+++ b/fdw/libchurl.c
@@ -512,7 +512,6 @@ churl_read_check_connectivity(CHURL_HANDLE handle)
 	Assert(!context->upload);
 
 	fill_internal_buffer(context, 1);
-	check_response(context);
 }
 
 /*
@@ -690,6 +689,8 @@ multi_perform(churl_context *context)
 	if (curl_error != CURLM_OK)
 		elog(ERROR, "internal error: curl_multi_perform failed (%d - %s)",
 			 curl_error, curl_easy_strerror(curl_error));
+
+	check_response(context);
 }
 
 static bool
@@ -717,13 +718,9 @@ flush_internal_buffer(churl_context *context)
 		multi_perform(context);
 	}
 
-	check_response(context);
-
 	if ((context->curl_still_running == 0) &&
 		((context_buffer->top - context_buffer->bot) > 0))
 		elog(ERROR, "failed sending to remote component %s", get_dest_address(context->curl_handle));
-
-	check_response(context);
 
 	context_buffer->top = 0;
 	context_buffer->bot = 0;
@@ -776,8 +773,6 @@ finish_upload(churl_context *context)
 	 */
 	while (context->curl_still_running != 0)
 		multi_perform(context);
-
-	check_response(context);
 }
 
 static void

--- a/fdw/libchurl.c
+++ b/fdw/libchurl.c
@@ -512,6 +512,7 @@ churl_read_check_connectivity(CHURL_HANDLE handle)
 	Assert(!context->upload);
 
 	fill_internal_buffer(context, 1);
+	check_response(context);
 }
 
 /*
@@ -689,8 +690,6 @@ multi_perform(churl_context *context)
 	if (curl_error != CURLM_OK)
 		elog(ERROR, "internal error: curl_multi_perform failed (%d - %s)",
 			 curl_error, curl_easy_strerror(curl_error));
-
-	check_response(context);
 }
 
 static bool
@@ -723,6 +722,8 @@ flush_internal_buffer(churl_context *context)
 	if ((context->curl_still_running == 0) &&
 		((context_buffer->top - context_buffer->bot) > 0))
 		elog(ERROR, "failed sending to remote component %s", get_dest_address(context->curl_handle));
+
+	check_response(context);
 
 	context_buffer->top = 0;
 	context_buffer->bot = 0;
@@ -775,6 +776,8 @@ finish_upload(churl_context *context)
 	 */
 	while (context->curl_still_running != 0)
 		multi_perform(context);
+
+	check_response(context);
 }
 
 static void


### PR DESCRIPTION
Commit 93f41a7477d668dda01cb9baca0a39a53f6958a6 moved the response check to `multi_perform`.
Later, when synchronizing (83cdc721ded68535a769f8ba67b28fbcbef40a12), one of the `check_response`
calls was returned. Since, in the commit b2c1a2794263a32abe1cbfcb265b63038b397e42,
the logic of the `flush_internal_buffer` function in fdw was synchronized with the
logic of the external table, and the call was moved a bit higher. Now, this call
is unnecessary because it will already be made in `multi_perform`.

This PR reapplies the old commit and removes the unnecessary `check_response` call.