### PR TITLE
Init foreign modify state early like it's done in 6.6.0

### DIFF
--- a/fdw/pxf_fdw.c
+++ b/fdw/pxf_fdw.c
@@ -610,6 +610,18 @@ pxfBeginForeignModify(ModifyTableState *mtstate,
 	 * external resource in the QD node, when all the actual insertions happen
 	 * in the segments.
 	 */
+	/* begin of temp block */
+	/*
+	 * Previously, ri_FdwState initialized here, but not in
+	 * pxfExecForeignInsert(). This was optimized, but unfortunately, there may
+	 * be some external projects that depend on old behavior. Here we do a temp
+	 * fix, which restores old behavior.
+	 */
+	if (eflags & EXEC_FLAG_EXPLAIN_ONLY)
+		return;
+	if (!resultRelInfo->ri_FdwState)
+		resultRelInfo->ri_FdwState = InitForeignModify(resultRelInfo->ri_RelationDesc);
+	/* end of temp block */
 }
 
 /*


### PR DESCRIPTION
The changes made in 27b899d96e111480e4f72d98b0323bbbe4021bb6 moved initialization of fdw global state to later phase - from pxfBeginForeignModify() to pxfExecForeignInsert(). This may break another projects which depend on pxf fdw. The patch temporary restores old behavior.
<details>
<summary>Spoiler</summary>
"another projects" is gptkh.

One of the concepts of gptkh is pxf fdw reusing.

https://gitlab.adsw.io/arenadata/development/gptkh#few-more-about-pxf

The main part of this reusing is a fdw curl headers tweaking.

https://gitlab.adsw.io/arenadata/development/gptkh/-/blob/main/src/tkh_skeleton_insert.c?ref_type=heads#L228

Currently, pxf fdw does global state [initialization](https://github.com/arenadata/pxf/blob/42e7fabd69bed1e3bcce4de33f0a5a2f4d3a0da2/fdw/pxf_fdw.c#L688) (including headers) and [sends](https://github.com/arenadata/pxf/blob/42e7fabd69bed1e3bcce4de33f0a5a2f4d3a0da2/fdw/pxf_fdw.c#L715) a query in a single pxfExecForeignInsert(), so there is no way to tweak headers between this two calls.

Another solution was to move a part of state initialization logic from fdw to gptkh, but collective brain decided to choose a cleaner, easier and much compact solution until gptkh will not remove all fdw dependencies from itself.

The easiest way to check that gptkh works with this patch as well, is to a take the name of image for current branch (gpdb6_pxf_regress:ADBDEV-4608), replace the latest image with it in docker/run.sh of gptkh project, init submodules as described in docker/README.md and run docker/run.sh. All tests should pass.

New tests for pxf are not needed. Pxf fdw already contains tests which should pass successfully.
</details>
