### PR TITLE
ADBDEV-5199: Add pxf thread pool executor metrics

### DIFF
--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/ServiceMetricsRestController.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/ServiceMetricsRestController.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.greenplum.pxf.service.rest.dto.ServiceMetricsDto;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.actuate.health.HealthEndpoint;
 import org.springframework.boot.actuate.metrics.MetricsEndpoint;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,6 +19,7 @@ import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/service-metrics")
+@ConditionalOnAvailableEndpoint(endpoint = MetricsEndpoint.class)
 public class ServiceMetricsRestController {
     private static final Collection<String> METRIC_NAMES = Arrays.asList(
             "http.server.requests",
@@ -32,7 +34,15 @@ public class ServiceMetricsRestController {
             "pxf.fragments.sent",
             "pxf.records.received",
             "pxf.records.sent",
-            "process.uptime"
+            "process.uptime",
+            "pxf.executor.active",
+            "pxf.executor.completed",
+            "pxf.executor.pool.core",
+            "pxf.executor.pool.max",
+            "pxf.executor.pool.size",
+            "pxf.executor.queue.remaining",
+            "pxf.executor.queued",
+            "pxf.executor.queue.capacity"
     );
     private static final Collection<String> CLUSTER_METRIC_NAMES = Arrays.asList(
             "jvm.memory.committed",
@@ -41,7 +51,15 @@ public class ServiceMetricsRestController {
             "pxf.bytes.received",
             "pxf.bytes.sent",
             "pxf.records.received",
-            "pxf.records.sent"
+            "pxf.records.sent",
+            "pxf.executor.active",
+            "pxf.executor.completed",
+            "pxf.executor.pool.core",
+            "pxf.executor.pool.max",
+            "pxf.executor.pool.size",
+            "pxf.executor.queue.remaining",
+            "pxf.executor.queued",
+            "pxf.executor.queue.capacity"
     );
     private final MetricsEndpoint metricsEndpoint;
     private final String clusterName;
@@ -63,9 +81,9 @@ public class ServiceMetricsRestController {
         return new ServiceMetricsDto(
                 healthEndpoint.health().getStatus().getCode(),
                 METRIC_NAMES.stream()
-                    .map(name -> metricsEndpoint.metric(name, Collections.emptyList()))
-                    .filter(Objects::nonNull)
-                    .collect(Collectors.toList())
+                        .map(name -> metricsEndpoint.metric(name, Collections.emptyList()))
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList())
         );
     }
 


### PR DESCRIPTION
- Change the prefix for all pxf executor metrics to pxf.

- Added additional metric to show thread pool max queue capacity : pxf.executor.queue.capacity

- Added all pxf executor metrics for endpoints /service-metrics and /service-metrics/cluster-metrics
