### PR TITLE
ADBDEV-5743: [Java] Extend support for year > 4 digits and BC/AD dating notation

### DIFF
--- a/automation/arenadata/Dockerfile
+++ b/automation/arenadata/Dockerfile
@@ -1,5 +1,5 @@
 FROM hub.adsw.io/library/gpdb6_regress:latest
-RUN sudo yum install -y epel-release  python-pip
+RUN sudo yum install -y epel-release
 
 # install maven
 RUN wget --no-check-certificate https://dlcdn.apache.org/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz -P /tmp \
@@ -63,7 +63,6 @@ RUN mkdir workspace && ln -s /home/gpadmin/pxf_src /home/gpadmin/workspace/pxf &
 
 # Need to run automation tests
 ENV PXF_HOME=/usr/local/greenplum-db-devel/pxf
-RUN sudo -H -u gpadmin bash -c "pip install --user paramiko"
 RUN localedef -c -i ru_RU -f CP1251 ru_RU.CP1251
 RUN cp ${PXF_HOME}/templates/*-site.xml ${PXF_HOME}/servers/default/
 

--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcPartitionFragmenter.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcPartitionFragmenter.java
@@ -38,6 +38,7 @@ public class JdbcPartitionFragmenter extends BaseFragmenter {
     private String column;
     private String range;
     private String interval;
+    protected boolean isDateWideRange;
 
     @Override
     public void afterPropertiesSet() {
@@ -54,6 +55,7 @@ public class JdbcPartitionFragmenter extends BaseFragmenter {
 
         range = context.getOption("RANGE");
         interval = context.getOption("INTERVAL");
+        isDateWideRange = JdbcBasePlugin.getIsDateWideRange(context);
     }
 
     /**
@@ -67,7 +69,9 @@ public class JdbcPartitionFragmenter extends BaseFragmenter {
         if (partitionType == null) {
             fragments.add(new Fragment(context.getDataSource()));
         } else {
-            List<JdbcFragmentMetadata> fragmentsMetadata = partitionType.getFragmentsMetadata(column, range, interval);
+            List<JdbcFragmentMetadata> fragmentsMetadata = partitionType.getFragmentsMetadata(
+                    column, range, interval, isDateWideRange
+            );
             for (JdbcFragmentMetadata fragmentMetadata : fragmentsMetadata) {
                 fragments.add(new Fragment(context.getDataSource(), fragmentMetadata));
             }

--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcResolver.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcResolver.java
@@ -19,7 +19,6 @@ package org.greenplum.pxf.plugins.jdbc;
  * under the License.
  */
 
-import org.greenplum.pxf.api.GreenplumDateTime;
 import io.arenadata.security.encryption.client.service.DecryptClient;
 import org.greenplum.pxf.api.OneField;
 import org.greenplum.pxf.api.OneRow;
@@ -42,87 +41,24 @@ import java.text.ParseException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
-import java.time.format.SignStyle;
-import java.time.temporal.ChronoField;
 import java.util.EnumSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
-import static java.time.format.DateTimeFormatter.ISO_OFFSET_TIME;
+import static org.greenplum.pxf.api.GreenplumDateTime.DATETIME_FORMATTER;
+import static org.greenplum.pxf.api.GreenplumDateTime.DATE_FORMATTER;
+import static org.greenplum.pxf.plugins.jdbc.utils.DateTimeEraFormatters.LOCAL_DATE_FORMATTER;
+import static org.greenplum.pxf.plugins.jdbc.utils.DateTimeEraFormatters.LOCAL_DATE_TIME_FORMATTER;
+import static org.greenplum.pxf.plugins.jdbc.utils.DateTimeEraFormatters.OFFSET_DATE_TIME_FORMATTER;
+import static org.greenplum.pxf.plugins.jdbc.utils.DateTimeEraFormatters.getLocalDate;
+import static org.greenplum.pxf.plugins.jdbc.utils.DateTimeEraFormatters.getLocalDateTime;
 
 /**
  * JDBC tables resolver
  */
 public class JdbcResolver extends JdbcBasePlugin implements Resolver {
-    // Signifies the ERA format
-    final private static String DATE_TIME_FORMATTER_SPECIFIER = " G";
-    /**
-     * LOCAL_DATE_GET_FORMATTER is used to format LocalDate to String.
-     * Examples: 2023-01-10 -> "2023-01-10 AD"; +12345-02-01 -> "12345-02-01 AD"; -0009-12-11 -> "0010-12-11 BC"
-     */
-    private static final DateTimeFormatter LOCAL_DATE_GET_FORMATTER = (new DateTimeFormatterBuilder())
-            .appendValue(ChronoField.YEAR_OF_ERA, 4, 9, SignStyle.NORMAL).appendLiteral("-")
-            .appendValue(ChronoField.MONTH_OF_YEAR, 2).appendLiteral('-')
-            .appendValue(ChronoField.DAY_OF_MONTH, 2)
-            .appendPattern(DATE_TIME_FORMATTER_SPECIFIER)
-            .toFormatter();
-
-    /**
-     * LOCAL_DATE_TIME_GET_FORMATTER is used to format LocalDateTime to String.
-     * Examples: 2018-10-19T10:11 -> "2018-10-19 10:11:00 AD"; +123456-10-19T11:12:13 -> "123456-10-19 11:12:13 AD";
-     * -1233-10-19T10:11:15.456 -> "1234-10-19 10:11:15.456 BC"
-     */
-    private static final DateTimeFormatter LOCAL_DATE_TIME_GET_FORMATTER = (new DateTimeFormatterBuilder())
-            .appendValue(ChronoField.YEAR_OF_ERA, 4, 9, SignStyle.NORMAL).appendLiteral("-")
-            .appendValue(ChronoField.MONTH_OF_YEAR, 2).appendLiteral('-')
-            .appendValue(ChronoField.DAY_OF_MONTH, 2).appendLiteral(" ")
-            .append(ISO_LOCAL_TIME)
-            .appendPattern(DATE_TIME_FORMATTER_SPECIFIER)
-            .toFormatter();
-
-
-    /**
-     * OFFSET_DATE_TIME_GET_FORMATTER is used to format OffsetDateTime to String.
-     * Examples: 1956-02-01T07:15:16Z -> "1956-02-01 07:15:16Z AD"; +12345-02-01T10:15:16Z -> "12345-02-01 10:15:16Z AD";
-     * -1999-02-01T04:15:16Z -> "2000-02-01 04:15:16Z BC"
-     */
-    private static final DateTimeFormatter OFFSET_DATE_TIME_GET_FORMATTER = (new DateTimeFormatterBuilder())
-            .appendValue(ChronoField.YEAR_OF_ERA, 4, 9, SignStyle.NORMAL).appendLiteral("-")
-            .appendValue(ChronoField.MONTH_OF_YEAR, 2).appendLiteral('-')
-            .appendValue(ChronoField.DAY_OF_MONTH, 2).appendLiteral(" ")
-            .append(ISO_OFFSET_TIME)
-            .appendPattern(DATE_TIME_FORMATTER_SPECIFIER)
-            .toFormatter();
-
-    /**
-     * LOCAL_DATE_SET_FORMATTER is used to format String to LocalDate.
-     * Examples: "1977-12-11" -> 1977-12-11; "456789-12-11" -> +456789-12-11; "0010-12-11 BC" -> -0009-12-11
-     */
-    private static final DateTimeFormatter LOCAL_DATE_SET_FORMATTER = (new DateTimeFormatterBuilder())
-            .appendValue(ChronoField.YEAR_OF_ERA, 1, 9, SignStyle.NORMAL).appendLiteral('-')
-            .appendValue(ChronoField.MONTH_OF_YEAR, 2).appendLiteral('-')
-            .appendValue(ChronoField.DAY_OF_MONTH, 2)
-            .optionalStart().appendPattern(DATE_TIME_FORMATTER_SPECIFIER).optionalEnd()
-            .toFormatter();
-
-    /**
-     * LOCAL_DATE_TIME_SET_FORMATTER is used to transfer String to LocalDateTime.
-     * Examples: "1980-08-10 17:10:20" -> 1980-08-10T17:10:20; "123456-10-19 11:12:13" -> +123456-10-19T11:12:13;
-     * "1234-10-19 10:11:15.456 BC" -> -1233-10-19T10:11:15.456
-     */
-    private static final DateTimeFormatter LOCAL_DATE_TIME_SET_FORMATTER = (new DateTimeFormatterBuilder())
-            .appendValue(ChronoField.YEAR_OF_ERA, 1, 9, SignStyle.NORMAL).appendLiteral('-')
-            .appendValue(ChronoField.MONTH_OF_YEAR, 1, 2, SignStyle.NORMAL).appendLiteral('-')
-            .appendValue(ChronoField.DAY_OF_MONTH, 1, 2, SignStyle.NORMAL).appendLiteral(" ")
-            .append(ISO_LOCAL_TIME)
-            .optionalStart().appendPattern(DATE_TIME_FORMATTER_SPECIFIER).optionalEnd()
-            .toFormatter();
-
     private static final Set<DataType> DATATYPES_SUPPORTED = EnumSet.of(
             DataType.VARCHAR,
             DataType.BPCHAR,
@@ -216,25 +152,25 @@ public class JdbcResolver extends JdbcBasePlugin implements Resolver {
                 case DATE:
                     if (isDateWideRange) {
                         LocalDate localDate = result.getObject(colName, LocalDate.class);
-                        value = localDate != null ? localDate.format(LOCAL_DATE_GET_FORMATTER) : null;
+                        value = localDate != null ? localDate.format(LOCAL_DATE_FORMATTER) : null;
                     } else {
                         Date date = result.getDate(colName);
-                        value = date != null ? date.toLocalDate().format(GreenplumDateTime.DATE_FORMATTER) : null;
+                        value = date != null ? date.toLocalDate().format(DATE_FORMATTER) : null;
                     }
                     break;
                 case TIMESTAMP:
                     if (isDateWideRange) {
                         LocalDateTime localDateTime = result.getObject(colName, LocalDateTime.class);
-                        value = localDateTime != null ? localDateTime.format(LOCAL_DATE_TIME_GET_FORMATTER) : null;
+                        value = localDateTime != null ? localDateTime.format(LOCAL_DATE_TIME_FORMATTER) : null;
                     } else {
                         Timestamp timestamp = result.getTimestamp(colName);
-                        value = timestamp != null ? timestamp.toLocalDateTime().format(GreenplumDateTime.DATETIME_FORMATTER) : null;
+                        value = timestamp != null ? timestamp.toLocalDateTime().format(DATETIME_FORMATTER) : null;
                     }
                     break;
                 case TIMESTAMP_WITH_TIME_ZONE:
                     if (isDateWideRange) {
                         OffsetDateTime offsetDateTime = result.getObject(colName, OffsetDateTime.class);
-                        value = offsetDateTime != null ? offsetDateTime.format(OFFSET_DATE_TIME_GET_FORMATTER) : null;
+                        value = offsetDateTime != null ? offsetDateTime.format(OFFSET_DATE_TIME_FORMATTER) : null;
                     } else {
                         throw new UnsupportedOperationException(
                                 String.format("Field type '%s' (column '%s') is not supported",
@@ -466,34 +402,6 @@ public class JdbcResolver extends JdbcBasePlugin implements Resolver {
                 default:
                     throw new IOException("The data tuple from JdbcResolver is corrupted");
             }
-        }
-    }
-
-    /**
-     * Convert a string to LocalDate class with formatter
-     *
-     * @param rawVal the LocalDate in a string format
-     * @return LocalDate
-     */
-    private LocalDate getLocalDate(String rawVal) {
-        try {
-            return LocalDate.parse(rawVal, LOCAL_DATE_SET_FORMATTER);
-        } catch (Exception e) {
-            throw new IllegalArgumentException("Failed to convert date '" + rawVal + "' to LocalDate class: " + e.getMessage(), e);
-        }
-    }
-
-    /**
-     * Convert a string to LocalDateTime class with formatter
-     *
-     * @param rawVal the LocalDateTime in a string format
-     * @return LocalDateTime
-     */
-    private LocalDateTime getLocalDateTime(String rawVal) {
-        try {
-            return LocalDateTime.parse(rawVal, LOCAL_DATE_TIME_SET_FORMATTER);
-        } catch (Exception e) {
-            throw new IllegalArgumentException("Failed to convert timestamp '" + rawVal + "' to the LocalDateTime class: " + e.getMessage(), e);
         }
     }
 }

--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/partitioning/BasePartition.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/partitioning/BasePartition.java
@@ -1,7 +1,6 @@
 package org.greenplum.pxf.plugins.jdbc.partitioning;
 
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
@@ -10,39 +9,20 @@ import lombok.RequiredArgsConstructor;
  * <p>
  * All partitions use some column as a partition column. It is processed by this class.
  */
-@NoArgsConstructor
+@Getter
 @RequiredArgsConstructor
 public abstract class BasePartition implements JdbcFragmentMetadata {
 
     /**
      * Column name to use as a partition column. Must not be null
      */
-    @Getter
     @NonNull
-    protected String column;
+    protected final String column;
 
-    /**
-     * Generate a range-based SQL constraint
-     *
-     * @param quotedColumn column name (used as is, thus it should be quoted if necessary)
-     * @param range        range to base constraint on
-     * @return a pure SQL constraint (without WHERE)
-     */
-    String generateRangeConstraint(String quotedColumn, String[] range) {
-        StringBuilder sb = new StringBuilder(quotedColumn);
-
-        if (range.length == 1) {
-            sb.append(" = ").append(range[0]);
-        } else if (range[0] == null) {
-            sb.append(" < ").append(range[1]);
-        } else if (range[1] == null) {
-            sb.append(" >= ").append(range[0]);
-        } else {
-            sb.append(" >= ").append(range[0])
-                    .append(" AND ")
-                    .append(quotedColumn).append(" < ").append(range[1]);
+    protected String getQuotedColumn(String quoteString) {
+        if (quoteString == null) {
+            throw new RuntimeException("Quote string cannot be null");
         }
-
-        return sb.toString();
+        return quoteString + column + quoteString;
     }
 }

--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/partitioning/BaseRangePartition.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/partitioning/BaseRangePartition.java
@@ -1,0 +1,38 @@
+package org.greenplum.pxf.plugins.jdbc.partitioning;
+
+import lombok.NonNull;
+
+/**
+ * A base class for partition of any type.
+ * <p>
+ * All partitions use some column as a partition column. It is processed by this class.
+ */
+public abstract class BaseRangePartition extends BasePartition {
+    public BaseRangePartition(@NonNull String column) {
+        super(column);
+    }
+
+    /**
+     * Generate a range-based SQL constraint
+     *
+     * @param quotedColumn column name (used as is, thus it should be quoted if necessary)
+     * @param start        range start to base constraint on
+     * @param end          range end to base constraint on
+     * @return a pure SQL constraint (without WHERE)
+     */
+    String generateRangeConstraint(String quotedColumn, String start, String end) {
+        StringBuilder sb = new StringBuilder(quotedColumn);
+
+        if (start == null) {
+            sb.append(" < ").append(end);
+        } else if (end == null) {
+            sb.append(" >= ").append(start);
+        } else {
+            sb.append(" >= ").append(start)
+                    .append(" AND ")
+                    .append(quotedColumn).append(" < ").append(end);
+        }
+
+        return sb.toString();
+    }
+}

--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/partitioning/BaseValuePartition.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/partitioning/BaseValuePartition.java
@@ -1,0 +1,25 @@
+package org.greenplum.pxf.plugins.jdbc.partitioning;
+
+import lombok.NonNull;
+
+/**
+ * A base class for partition of any type.
+ * <p>
+ * All partitions use some column as a partition column. It is processed by this class.
+ */
+public abstract class BaseValuePartition extends BasePartition {
+    public BaseValuePartition(@NonNull String column) {
+        super(column);
+    }
+
+    /**
+     * Generate a range-based SQL constraint
+     *
+     * @param quotedColumn column name (used as is, thus it should be quoted if necessary)
+     * @param value        value to base constraint on
+     * @return a pure SQL constraint (without WHERE)
+     */
+    String generateConstraint(String quotedColumn, String value) {
+        return quotedColumn + " = " + value;
+    }
+}

--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/partitioning/IntValuePartition.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/partitioning/IntValuePartition.java
@@ -19,22 +19,39 @@ package org.greenplum.pxf.plugins.jdbc.partitioning;
  * under the License.
  */
 
-import java.util.Objects;
+import lombok.Getter;
+import org.greenplum.pxf.plugins.jdbc.utils.DbProduct;
 
-public interface IntPartition extends JdbcFragmentMetadata {
-    Long getStart();
-    Long getEnd();
 
-    static IntPartition create(String column, Long start, Long end) {
-        if (start == null && end == null) {
-            throw new RuntimeException("Both boundaries cannot be null");
-        }
-        return Objects.equals(start, end) ?
-                new IntValuePartition(column, start) :
-                new IntRangePartition(column, start, end);
+@Getter
+public class IntValuePartition extends BaseValuePartition implements IntPartition {
+
+    private final long value;
+
+    /**
+     * @param column the partition column
+     * @param value  value to base constraint on
+     */
+    public IntValuePartition(String column, long value) {
+        super(column);
+        this.value = value;
     }
 
-    static String convert(Long b) {
-        return b == null ? null : b.toString();
+    @Override
+    public String toSqlConstraint(String quoteString, DbProduct dbProduct) {
+        return generateConstraint(
+                getQuotedColumn(quoteString),
+                String.valueOf(value)
+        );
+    }
+
+    @Override
+    public Long getStart() {
+        return value;
+    }
+
+    @Override
+    public Long getEnd() {
+        return value;
     }
 }

--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/utils/DateTimeEraFormatters.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/utils/DateTimeEraFormatters.java
@@ -26,7 +26,7 @@ public class DateTimeEraFormatters {
             .appendText(ChronoField.ERA, TextStyle.SHORT)
             .toFormatter();
     /**
-     * LOCAL_DATE_TIME_SET_FORMATTER is used to parse String to LocalDateTime.
+     * Used to parse String to LocalDateTime.
      * Examples: "1980-08-10 17:10:20" -> 1980-08-10T17:10:20; "123456-10-19 11:12:13" -> +123456-10-19T11:12:13;
      * "1234-10-19 10:11:15.456 BC" -> -1233-10-19T10:11:15.456
      */
@@ -39,7 +39,7 @@ public class DateTimeEraFormatters {
             .toFormatter()
             .withLocale(Locale.ROOT);
     /**
-     * LOCAL_DATE_SET_FORMATTER is used to parse String to LocalDate.
+     * Used to parse String to LocalDate.
      * Examples: "1977-12-11" -> 1977-12-11; "456789-12-11" -> +456789-12-11; "0010-12-11 BC" -> -0009-12-11
      */
     public static final DateTimeFormatter LOCAL_DATE_PARSE_FORMATTER = new DateTimeFormatterBuilder()
@@ -50,7 +50,7 @@ public class DateTimeEraFormatters {
             .toFormatter()
             .withLocale(Locale.ROOT);
     /**
-     * OFFSET_DATE_TIME_GET_FORMATTER is used to format OffsetDateTime to String.
+     * Used to format OffsetDateTime to String.
      * Examples: 1956-02-01T07:15:16Z -> "1956-02-01 07:15:16Z AD"; +12345-02-01T10:15:16Z -> "12345-02-01 10:15:16Z AD";
      * -1999-02-01T04:15:16Z -> "2000-02-01 04:15:16Z BC"
      */
@@ -63,7 +63,7 @@ public class DateTimeEraFormatters {
             .toFormatter()
             .withLocale(Locale.ROOT);
     /**
-     * LOCAL_DATE_TIME_GET_FORMATTER is used to format LocalDateTime to String.
+     * Used to format LocalDateTime to String.
      * Examples: 2018-10-19T10:11 -> "2018-10-19 10:11:00 AD"; +123456-10-19T11:12:13 -> "123456-10-19 11:12:13 AD";
      * -1233-10-19T10:11:15.456 -> "1234-10-19 10:11:15.456 BC"
      */
@@ -76,7 +76,7 @@ public class DateTimeEraFormatters {
             .toFormatter()
             .withLocale(Locale.ROOT);
     /**
-     * LOCAL_DATE_GET_FORMATTER is used to format LocalDate to String.
+     * Used to format LocalDate to String.
      * Examples: 2023-01-10 -> "2023-01-10 AD"; +12345-02-01 -> "12345-02-01 AD"; -0009-12-11 -> "0010-12-11 BC"
      */
     public static final DateTimeFormatter LOCAL_DATE_FORMATTER = new DateTimeFormatterBuilder()

--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/utils/DateTimeEraFormatters.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/utils/DateTimeEraFormatters.java
@@ -1,0 +1,117 @@
+package org.greenplum.pxf.plugins.jdbc.utils;
+
+import lombok.experimental.UtilityClass;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.SignStyle;
+import java.time.format.TextStyle;
+import java.time.temporal.ChronoField;
+import java.util.Locale;
+
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_TIME;
+
+@UtilityClass
+public class DateTimeEraFormatters {
+
+    /**
+     * Signifies the ERA
+     * Examples: " AD"; " BC"
+     */
+    public final static DateTimeFormatter ERA_FORMATTER = new DateTimeFormatterBuilder()
+            .appendLiteral(" ")
+            .appendText(ChronoField.ERA, TextStyle.SHORT)
+            .toFormatter();
+    /**
+     * LOCAL_DATE_TIME_SET_FORMATTER is used to parse String to LocalDateTime.
+     * Examples: "1980-08-10 17:10:20" -> 1980-08-10T17:10:20; "123456-10-19 11:12:13" -> +123456-10-19T11:12:13;
+     * "1234-10-19 10:11:15.456 BC" -> -1233-10-19T10:11:15.456
+     */
+    public static final DateTimeFormatter LOCAL_DATE_TIME_PARSE_FORMATTER = new DateTimeFormatterBuilder()
+            .appendValue(ChronoField.YEAR_OF_ERA, 1, 9, SignStyle.NORMAL).appendLiteral('-')
+            .appendValue(ChronoField.MONTH_OF_YEAR, 1, 2, SignStyle.NORMAL).appendLiteral('-')
+            .appendValue(ChronoField.DAY_OF_MONTH, 1, 2, SignStyle.NORMAL).appendLiteral(" ")
+            .append(ISO_LOCAL_TIME)
+            .appendOptional(ERA_FORMATTER)
+            .toFormatter()
+            .withLocale(Locale.ROOT);
+    /**
+     * LOCAL_DATE_SET_FORMATTER is used to parse String to LocalDate.
+     * Examples: "1977-12-11" -> 1977-12-11; "456789-12-11" -> +456789-12-11; "0010-12-11 BC" -> -0009-12-11
+     */
+    public static final DateTimeFormatter LOCAL_DATE_PARSE_FORMATTER = new DateTimeFormatterBuilder()
+            .appendValue(ChronoField.YEAR_OF_ERA, 1, 9, SignStyle.NORMAL).appendLiteral('-')
+            .appendValue(ChronoField.MONTH_OF_YEAR, 2).appendLiteral('-')
+            .appendValue(ChronoField.DAY_OF_MONTH, 2)
+            .appendOptional(ERA_FORMATTER)
+            .toFormatter()
+            .withLocale(Locale.ROOT);
+    /**
+     * OFFSET_DATE_TIME_GET_FORMATTER is used to format OffsetDateTime to String.
+     * Examples: 1956-02-01T07:15:16Z -> "1956-02-01 07:15:16Z AD"; +12345-02-01T10:15:16Z -> "12345-02-01 10:15:16Z AD";
+     * -1999-02-01T04:15:16Z -> "2000-02-01 04:15:16Z BC"
+     */
+    public static final DateTimeFormatter OFFSET_DATE_TIME_FORMATTER = new DateTimeFormatterBuilder()
+            .appendValue(ChronoField.YEAR_OF_ERA, 4, 9, SignStyle.NORMAL).appendLiteral("-")
+            .appendValue(ChronoField.MONTH_OF_YEAR, 2).appendLiteral('-')
+            .appendValue(ChronoField.DAY_OF_MONTH, 2).appendLiteral(" ")
+            .append(ISO_OFFSET_TIME)
+            .appendOptional(ERA_FORMATTER)
+            .toFormatter()
+            .withLocale(Locale.ROOT);
+    /**
+     * LOCAL_DATE_TIME_GET_FORMATTER is used to format LocalDateTime to String.
+     * Examples: 2018-10-19T10:11 -> "2018-10-19 10:11:00 AD"; +123456-10-19T11:12:13 -> "123456-10-19 11:12:13 AD";
+     * -1233-10-19T10:11:15.456 -> "1234-10-19 10:11:15.456 BC"
+     */
+    public static final DateTimeFormatter LOCAL_DATE_TIME_FORMATTER = new DateTimeFormatterBuilder()
+            .appendValue(ChronoField.YEAR_OF_ERA, 4, 9, SignStyle.NORMAL).appendLiteral("-")
+            .appendValue(ChronoField.MONTH_OF_YEAR, 2).appendLiteral('-')
+            .appendValue(ChronoField.DAY_OF_MONTH, 2).appendLiteral(" ")
+            .append(ISO_LOCAL_TIME)
+            .appendOptional(ERA_FORMATTER)
+            .toFormatter()
+            .withLocale(Locale.ROOT);
+    /**
+     * LOCAL_DATE_GET_FORMATTER is used to format LocalDate to String.
+     * Examples: 2023-01-10 -> "2023-01-10 AD"; +12345-02-01 -> "12345-02-01 AD"; -0009-12-11 -> "0010-12-11 BC"
+     */
+    public static final DateTimeFormatter LOCAL_DATE_FORMATTER = new DateTimeFormatterBuilder()
+            .appendValue(ChronoField.YEAR_OF_ERA, 4, 9, SignStyle.NEVER).appendLiteral("-")
+            .appendValue(ChronoField.MONTH_OF_YEAR, 2).appendLiteral('-')
+            .appendValue(ChronoField.DAY_OF_MONTH, 2)
+            .appendOptional(ERA_FORMATTER)
+            .toFormatter()
+            .withLocale(Locale.ROOT);
+
+    /**
+     * Convert a string to LocalDate class with formatter
+     *
+     * @param rawVal the LocalDate in a string format
+     * @return LocalDate
+     */
+    public static LocalDate getLocalDate(String rawVal) {
+        try {
+            return LocalDate.parse(rawVal, LOCAL_DATE_PARSE_FORMATTER);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to convert date '" + rawVal + "' to LocalDate class: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Convert a string to LocalDateTime class with formatter
+     *
+     * @param rawVal the LocalDateTime in a string format
+     * @return LocalDateTime
+     */
+    public static LocalDateTime getLocalDateTime(String rawVal) {
+        try {
+            return LocalDateTime.parse(rawVal, LOCAL_DATE_TIME_PARSE_FORMATTER);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to convert timestamp '" + rawVal + "' to the LocalDateTime class: " + e.getMessage(), e);
+        }
+    }
+}

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcAccessorTest.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcAccessorTest.java
@@ -233,7 +233,7 @@ public class JdbcAccessorTest {
         context.addOption("PARTITION_BY", "count:int");
         context.addOption("RANGE", "1:10");
         context.addOption("INTERVAL", "1");
-        context.setFragmentMetadata(new IntPartition("count", 1L, 2L));
+        context.setFragmentMetadata(IntPartition.create("count", 1L, 2L));
         ArgumentCaptor<String> queryPassed = ArgumentCaptor.forClass(String.class);
         when(mockStatement.executeQuery(queryPassed.capture())).thenReturn(mockResultSet);
         wireMocksForReadWithCreateStatement();
@@ -257,7 +257,7 @@ public class JdbcAccessorTest {
         context.addOption("PARTITION_BY", "count:int");
         context.addOption("RANGE", "1:10");
         context.addOption("INTERVAL", "1");
-        context.setFragmentMetadata(new IntPartition("count", 1L, 2L));
+        context.setFragmentMetadata(IntPartition.create("count", 1L, 2L));
         ArgumentCaptor<String> queryPassed = ArgumentCaptor.forClass(String.class);
         when(mockStatement.executeQuery(queryPassed.capture())).thenReturn(mockResultSet);
         wireMocksForReadWithCreateStatement();

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/partitioning/DatePartitionTest.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/partitioning/DatePartitionTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DatePartitionTest {
 
-    private DbProduct dbProduct = DbProduct.POSTGRES;
+    private final DbProduct dbProduct = DbProduct.POSTGRES;
 
     private final String COL_RAW = "col";
     private final String QUOTE = "\"";
@@ -43,6 +43,18 @@ public class DatePartitionTest {
         assertEquals(
             COL + " >= date'2000-01-01' AND " + COL + " < date'2000-01-02'",
             constraint
+        );
+        assertEquals(COL_RAW, partition.getColumn());
+    }
+
+    @Test
+    public void testDateWideRange() {
+        DatePartition partition = new DatePartition(COL_RAW, LocalDate.of(-1, 2,3), LocalDate.of(99999, 4, 5), true);
+        String constraint = partition.toSqlConstraint(QUOTE, dbProduct);
+
+        assertEquals(
+                COL + " >= date'0002-02-03 BC' AND " + COL + " < date'99999-04-05 AD'",
+                constraint
         );
         assertEquals(COL_RAW, partition.getColumn());
     }

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/partitioning/EnumPartitionTestGenerate.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/partitioning/EnumPartitionTestGenerate.java
@@ -32,7 +32,8 @@ public class EnumPartitionTestGenerate {
         String COLUMN = "col";
         String RANGE = "excellent:good:general:bad";
 
-        EnumPartition[] parts = PartitionType.ENUM.generate(COLUMN, RANGE, null).stream().map(p -> EnumPartition.class.cast(p)).toArray(EnumPartition[]::new);
+        EnumPartition[] parts = PartitionType.ENUM.generate(COLUMN, RANGE, null, false).stream()
+                .map(p -> (EnumPartition) p).toArray(EnumPartition[]::new);
 
         assertEquals(5, parts.length);
         assertEnumPartitionEquals(parts[0], "excellent");
@@ -46,7 +47,8 @@ public class EnumPartitionTestGenerate {
         String COLUMN = "col";
         String RANGE = "100";
 
-        EnumPartition[] parts = PartitionType.ENUM.generate(COLUMN, RANGE, null).stream().map(p -> EnumPartition.class.cast(p)).toArray(EnumPartition[]::new);
+        EnumPartition[] parts = PartitionType.ENUM.generate(COLUMN, RANGE, null, false).stream()
+                .map(p -> (EnumPartition) p).toArray(EnumPartition[]::new);
 
         assertEquals(2, parts.length);
         assertEnumPartitionEquals(parts[0], "100");

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/partitioning/IntPartitionTest.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/partitioning/IntPartitionTest.java
@@ -35,7 +35,7 @@ public class IntPartitionTest {
 
     @Test
     public void testNormal() {
-        IntPartition partition = new IntPartition(COL_RAW, 0L, 1L);
+        IntPartition partition = IntPartition.create(COL_RAW, 0L, 1L);
         String constraint = partition.toSqlConstraint(QUOTE, dbProduct);
 
         assertEquals(COL + " >= 0 AND " + COL + " < 1", constraint);
@@ -43,7 +43,7 @@ public class IntPartitionTest {
 
     @Test
     public void testRightBounded() {
-        IntPartition partition = new IntPartition(COL_RAW, null, 0L);
+        IntPartition partition = IntPartition.create(COL_RAW, null, 0L);
         String constraint = partition.toSqlConstraint(QUOTE, dbProduct);
 
         assertEquals(COL + " < 0", constraint);
@@ -51,7 +51,7 @@ public class IntPartitionTest {
 
     @Test
     public void testLeftBounded() {
-        IntPartition partition = new IntPartition(COL_RAW, 0L, null);
+        IntPartition partition = IntPartition.create(COL_RAW, 0L, null);
         String constraint = partition.toSqlConstraint(QUOTE, dbProduct);
 
         assertEquals(COL + " >= 0", constraint);
@@ -59,7 +59,7 @@ public class IntPartitionTest {
 
     @Test
     public void testRightBoundedInclusive() {
-        IntPartition partition = new IntPartition(COL_RAW, null, 0L);
+        IntPartition partition = IntPartition.create(COL_RAW, null, 0L);
         String constraint = partition.toSqlConstraint(QUOTE, dbProduct);
 
         assertEquals(COL + " < 0", constraint);
@@ -67,7 +67,7 @@ public class IntPartitionTest {
 
     @Test
     public void testLeftBoundedInclusive() {
-        IntPartition partition = new IntPartition(COL_RAW, 0L, null);
+        IntPartition partition = IntPartition.create(COL_RAW, 0L, null);
         String constraint = partition.toSqlConstraint(QUOTE, dbProduct);
 
         assertEquals(COL + " >= 0", constraint);
@@ -75,27 +75,38 @@ public class IntPartitionTest {
 
     @Test
     public void testEqualBoundaries() {
-        IntPartition partition = new IntPartition(COL_RAW, 0L, 0L);
+        IntPartition partition = IntPartition.create(COL_RAW, 0L, 0L);
         String constraint = partition.toSqlConstraint(QUOTE, dbProduct);
 
         assertEquals(COL + " = 0", constraint);
     }
 
     @Test
+    public void testEqualBoundariesMaxValue() {
+        long value = Long.MAX_VALUE;
+        IntPartition partition = IntPartition.create(COL_RAW, value, value);
+        String constraint = partition.toSqlConstraint(QUOTE, dbProduct);
+
+        assertEquals(COL + " = " + value, constraint);
+    }
+
+    @Test
     public void testInvalidBothBoundariesNull() {
         assertThrows(RuntimeException.class,
-            () -> new IntPartition(COL_RAW, null, null));
+            () -> IntPartition.create(COL_RAW, null, null)
+        );
     }
 
     @Test
     public void testInvalidColumnNull() {
         assertThrows(RuntimeException.class,
-            () -> new IntPartition(null, 0L, 1L));
+            () -> IntPartition.create(null, 0L, 1L)
+        );
     }
 
     @Test
     public void testInvalidNullQuoteString() {
-        IntPartition partition = new IntPartition(COL_RAW, 0L, 1L);
+        IntPartition partition = IntPartition.create(COL_RAW, 0L, 1L);
 
         assertThrows(RuntimeException.class,
             () -> partition.toSqlConstraint(null, dbProduct));

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/partitioning/IntPartitionTestGenerate.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/partitioning/IntPartitionTestGenerate.java
@@ -32,7 +32,8 @@ public class IntPartitionTestGenerate {
         String RANGE = "2001:2012";
         String INTERVAL = "2";
 
-        IntPartition[] parts = PartitionType.INT.generate(COLUMN, RANGE, INTERVAL).stream().map(p -> IntPartition.class.cast(p)).toArray(IntPartition[]::new);
+        IntPartition[] parts = PartitionType.INT.generate(COLUMN, RANGE, INTERVAL, false).stream()
+                .map(p -> (IntPartition) p).toArray(IntPartition[]::new);
 
         assertEquals(8, parts.length);
         assertFragmentRangeEquals(parts[0], null, 2001L);
@@ -51,7 +52,8 @@ public class IntPartitionTestGenerate {
         String RANGE = "2001:2012";
         String INTERVAL = "7";
 
-        IntPartition[] parts = PartitionType.INT.generate(COLUMN, RANGE, INTERVAL).stream().map(p -> IntPartition.class.cast(p)).toArray(IntPartition[]::new);
+        IntPartition[] parts = PartitionType.INT.generate(COLUMN, RANGE, INTERVAL, false).stream()
+                .map(p -> (IntPartition) p).toArray(IntPartition[]::new);
 
         assertEquals(4, parts.length);
 
@@ -67,7 +69,7 @@ public class IntPartitionTestGenerate {
         final String RANGE = "42:17";
         final String INTERVAL = "2";
         assertThrows(IllegalArgumentException.class,
-            () -> PartitionType.INT.generate(COLUMN, RANGE, INTERVAL));
+            () -> PartitionType.INT.generate(COLUMN, RANGE, INTERVAL, false));
     }
 
     /**
@@ -78,8 +80,7 @@ public class IntPartitionTestGenerate {
      * @param rangeEnd   (null is allowed)
      */
     private void assertFragmentRangeEquals(IntPartition partition, Long rangeStart, Long rangeEnd) {
-        Long[] boundaries = partition.getBoundaries();
-        assertEquals(rangeStart, boundaries[0]);
-        assertEquals(rangeEnd, boundaries[1]);
+        assertEquals(rangeStart, partition.getStart());
+        assertEquals(rangeEnd, partition.getEnd());
     }
 }

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/partitioning/PartitionTypeTest.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/partitioning/PartitionTypeTest.java
@@ -10,54 +10,54 @@ public class PartitionTypeTest {
     @Test
     public void testErrorIfColumnNameIsNotProvided() {
         Exception ex = assertThrows(RuntimeException.class,
-            () -> PartitionType.INT.getFragmentsMetadata(null, "range", "interval"));
+            () -> PartitionType.INT.getFragmentsMetadata(null, "range", "interval", false));
         assertEquals("The column name must be provided", ex.getMessage());
     }
 
     @Test
     public void testErrorIfRangeIsNotProvidedForINT() {
         Exception ex = assertThrows(IllegalArgumentException.class,
-            () -> PartitionType.INT.getFragmentsMetadata("foo", null, "interval"));
+            () -> PartitionType.INT.getFragmentsMetadata("foo", null, "interval", false));
         assertEquals("The parameter 'RANGE' must be specified for partition of type 'INT'", ex.getMessage());
     }
 
     @Test
     public void testErrorIfRangeIsNotProvidedForENUM() {
         Exception ex = assertThrows(IllegalArgumentException.class,
-            () -> PartitionType.ENUM.getFragmentsMetadata("foo", null, "interval"));
+            () -> PartitionType.ENUM.getFragmentsMetadata("foo", null, "interval", false));
         assertEquals("The parameter 'RANGE' must be specified for partition of type 'ENUM'", ex.getMessage());
     }
 
     @Test
     public void testErrorIfRangeIsNotProvidedForDATE() {
         Exception ex = assertThrows(IllegalArgumentException.class,
-            () -> PartitionType.DATE.getFragmentsMetadata("foo", null, "interval"));
+            () -> PartitionType.DATE.getFragmentsMetadata("foo", null, "interval", false));
         assertEquals("The parameter 'RANGE' must be specified for partition of type 'DATE'", ex.getMessage());
     }
 
     @Test
     public void testErrorIfIntervalIsNotProvidedForINT() {
         Exception ex = assertThrows(IllegalArgumentException.class,
-            () -> PartitionType.INT.getFragmentsMetadata("foo", "bar", null));
+            () -> PartitionType.INT.getFragmentsMetadata("foo", "bar", null, false));
         assertEquals("The parameter 'INTERVAL' must be specified for partition of type 'INT'", ex.getMessage());
     }
 
     @Test
     public void testErrorIfIntervalIsNotProvidedForDATE() {
         Exception ex = assertThrows(IllegalArgumentException.class,
-            () -> PartitionType.DATE.getFragmentsMetadata("foo", "bar", null));
+            () -> PartitionType.DATE.getFragmentsMetadata("foo", "bar", null, false));
         assertEquals("The parameter 'INTERVAL' must be specified for partition of type 'DATE'", ex.getMessage());
     }
 
     @Test
     public void testSucceedsIfIntervalIsNotProvidedForENUM() {
-        PartitionType.ENUM.getFragmentsMetadata("foo", "bar", null);
+        PartitionType.ENUM.getFragmentsMetadata("foo", "bar", null, false);
     }
 
     @Test
     public void unsupportedCreatePartitionForEnum() {
         Exception e = assertThrows(UnsupportedOperationException.class,
-            () -> PartitionType.ENUM.createPartition(null, null, null));
+            () -> PartitionType.ENUM.createPartition(null, null, null, false));
         assertEquals("Current operation is not supported", e.getMessage());
     }
 
@@ -99,28 +99,28 @@ public class PartitionTypeTest {
     @Test
     public void testInvalidRangeForInt() {
         Exception ex = assertThrows(IllegalArgumentException.class,
-            () -> PartitionType.INT.getFragmentsMetadata("foo", "1", "1"));
+            () -> PartitionType.INT.getFragmentsMetadata("foo", "1", "1", false));
         assertEquals("The parameter 'RANGE' has incorrect format. The correct format for partition of type 'INT' is '<start_value>:<end_value>'", ex.getMessage());
     }
 
     @Test
     public void testInvalidRange2ForInt() {
         Exception ex = assertThrows(IllegalArgumentException.class,
-            () -> PartitionType.INT.getFragmentsMetadata("foo", "1:2:3", "1"));
+            () -> PartitionType.INT.getFragmentsMetadata("foo", "1:2:3", "1", false));
         assertEquals("The parameter 'RANGE' has incorrect format. The correct format for partition of type 'INT' is '<start_value>:<end_value>'", ex.getMessage());
     }
 
     @Test
     public void testInvalidRangeValuesForInt() {
         Exception ex = assertThrows(IllegalArgumentException.class,
-            () -> PartitionType.INT.getFragmentsMetadata("foo", "a:b", "1"));
+            () -> PartitionType.INT.getFragmentsMetadata("foo", "a:b", "1", false));
         assertEquals("The parameter 'RANGE' is invalid. The correct format for partition of type 'INT' is 'Integer'", ex.getMessage());
     }
 
     @Test
     public void testInvalidRangeValuesForDate() {
         Exception ex = assertThrows(IllegalArgumentException.class,
-            () -> PartitionType.DATE.getFragmentsMetadata("foo", "a:b", "1"));
+            () -> PartitionType.DATE.getFragmentsMetadata("foo", "a:b", "1", false));
         assertEquals("The parameter 'RANGE' is invalid. The correct format for partition of type 'DATE' is 'yyyy-mm-dd'", ex.getMessage());
     }
 }

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/utils/DbProductTest.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/utils/DbProductTest.java
@@ -25,6 +25,7 @@ import java.sql.Date;
 import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.LocalDate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -64,8 +65,20 @@ public class DbProductTest {
         DbProduct dbProduct = DbProduct.getDbProduct(DB_NAME_UNKNOWN);
 
         for (int i = 0; i < DATES.length; i++) {
-            assertEquals(expected[i], dbProduct.wrapDate(DATES[i]));
+            assertEquals(expected[i], dbProduct.wrapDate(String.valueOf(DATES[i])));
         }
+    }
+
+    /**
+     * This test also applies to Postgres database
+     */
+    @Test
+    public void testUnknownLocalDate() {
+        DbProduct dbProduct = DbProduct.getDbProduct(DB_NAME_UNKNOWN);
+        assertEquals("date'2001-03-04'", dbProduct.wrapDate(LocalDate.of(2001, 3, 4), false));
+        assertEquals("date'2001-03-04 AD'", dbProduct.wrapDate(LocalDate.of(2001, 3, 4), true));
+        assertEquals("date'99999-03-04 AD'", dbProduct.wrapDate(LocalDate.of(99999, 3, 4), true));
+        assertEquals("date'0501-03-04 BC'", dbProduct.wrapDate(LocalDate.of(-500, 3, 4), true));
     }
 
     /**
@@ -78,7 +91,7 @@ public class DbProductTest {
         DbProduct dbProduct = DbProduct.getDbProduct(DB_NAME_UNKNOWN);
 
         for (int i = 0; i < TIMESTAMPS.length; i++) {
-            assertEquals(expected[i], dbProduct.wrapTimestamp(TIMESTAMPS[i]));
+            assertEquals(expected[i], dbProduct.wrapTimestamp(String.valueOf(TIMESTAMPS[i])));
         }
     }
 
@@ -92,8 +105,16 @@ public class DbProductTest {
         DbProduct dbProduct = DbProduct.getDbProduct(DB_NAME_ORACLE);
 
         for (int i = 0; i < DATES.length; i++) {
-            assertEquals(expected[i], dbProduct.wrapDate(DATES[i]));
+            assertEquals(expected[i], dbProduct.wrapDate(String.valueOf(DATES[i])));
         }
+    }
+
+    @Test
+    public void testOracleLocalDate() {
+        DbProduct dbProduct = DbProduct.getDbProduct(DB_NAME_ORACLE);
+        assertEquals("to_date('2001-03-04', 'YYYY-MM-DD')", dbProduct.wrapDate(LocalDate.of(2001, 3, 4), false));
+        assertEquals("to_date('2001-03-04', 'YYYY-MM-DD')", dbProduct.wrapDate(LocalDate.of(2001, 3, 4), true));
+        assertEquals("to_date('-0500-03-04', 'YYYY-MM-DD')", dbProduct.wrapDate(LocalDate.of(-500, 3, 4), true));
     }
 
     @Test
@@ -103,7 +124,7 @@ public class DbProductTest {
         DbProduct dbProduct = DbProduct.getDbProduct(DB_NAME_ORACLE);
 
         for (int i = 0; i < TIMESTAMPS.length; i++) {
-            assertEquals(expected[i], dbProduct.wrapDateWithTime(TIMESTAMPS[i]));
+            assertEquals(expected[i], dbProduct.wrapDateWithTime(String.valueOf(TIMESTAMPS[i])));
         }
     }
 
@@ -114,7 +135,7 @@ public class DbProductTest {
         DbProduct dbProduct = DbProduct.getDbProduct(DB_NAME_ORACLE);
 
         for (int i = 0; i < TIMESTAMPS.length; i++) {
-            assertEquals(expected[i], dbProduct.wrapTimestamp(TIMESTAMPS[i]));
+            assertEquals(expected[i], dbProduct.wrapTimestamp(String.valueOf(TIMESTAMPS[i])));
         }
     }
 
@@ -128,7 +149,7 @@ public class DbProductTest {
         DbProduct dbProduct = DbProduct.getDbProduct(DB_NAME_MICROSOFT);
 
         for (int i = 0; i < DATES.length; i++) {
-            assertEquals(expected[i], dbProduct.wrapDate(DATES[i]));
+            assertEquals(expected[i], dbProduct.wrapDate(String.valueOf(DATES[i])));
         }
     }
 
@@ -142,7 +163,7 @@ public class DbProductTest {
         DbProduct dbProduct = DbProduct.getDbProduct(DB_NAME_MYSQL);
 
         for (int i = 0; i < DATES.length; i++) {
-            assertEquals(expected[i], dbProduct.wrapDate(DATES[i]));
+            assertEquals(expected[i], dbProduct.wrapDate(String.valueOf(DATES[i])));
         }
     }
 }


### PR DESCRIPTION
Add extra support for wide range dates  to Fragmenter.

- Refactoring of `jdbc.partitioning` package, `DbProduct`, `JdbcResolver` 
- Fix bug in IntPartition (`Long == Long`)
- Support wide range dates in `PartitionType.DATE.parseRange()`
- Support wide range dates in `DatePartition.toSqlConstraint()` if `isDateWideRange` is true