### PR TITLE
ADBDEV-5823: [Java] Throw an exception when an unsuitable JDBC driver class is specified

### DIFF
--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/FakeJdbcDriver.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/FakeJdbcDriver.java
@@ -1,14 +1,28 @@
 package org.greenplum.pxf.plugins.jdbc;
 
+import lombok.Getter;
+
 import java.sql.Connection;
 import java.sql.Driver;
+import java.sql.DriverManager;
 import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.Properties;
 import java.util.logging.Logger;
 
+import static org.mockito.Mockito.mock;
+
 public class FakeJdbcDriver implements Driver {
+    @Getter
+    private static final Driver mockDriver = mock(FakeJdbcDriver.class);
+    static {
+        try {
+            DriverManager.registerDriver(mockDriver);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     public Connection connect(String url, Properties info) throws SQLException {
         return null;

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/utils/ConnectionManagerTest.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/utils/ConnectionManagerTest.java
@@ -77,11 +77,10 @@ public class ConnectionManagerTest {
 
     @Test
     public void testGetConnectionPoolEnabledNoPoolProps() throws SQLException {
-        Driver mockDriver = mock(FakeJdbcDriver.class);
+        Driver mockDriver = FakeJdbcDriver.getMockDriver();
         when(mockDriverManagerWrapper.getDriver("test-url")).thenReturn(mockDriver);
         when(mockDriver.connect("test-url", connProps)).thenReturn(mockConnection);
         when(mockDriver.acceptsURL("test-url")).thenReturn(true);
-        DriverManager.registerDriver(mockDriver);
 
         Driver mockDriver2 = mock(FakeJdbcDriver2.class);
         when(mockDriverManagerWrapper.getDriver("test-url-2")).thenReturn(mockDriver2);
@@ -113,11 +112,10 @@ public class ConnectionManagerTest {
 
     @Test
     public void testGetConnectionPoolEnabledMaxConnOne() throws SQLException {
-        Driver mockDriver = mock(FakeJdbcDriver.class);
+        Driver mockDriver = FakeJdbcDriver.getMockDriver();
         when(mockDriverManagerWrapper.getDriver("test-url")).thenReturn(mockDriver);
         when(mockDriver.connect("test-url", connProps)).thenReturn(mockConnection);
         when(mockDriver.acceptsURL("test-url")).thenReturn(true);
-        DriverManager.registerDriver(mockDriver);
 
         poolProps.setProperty("maximumPoolSize", "1");
         poolProps.setProperty("connectionTimeout", "250");
@@ -134,11 +132,10 @@ public class ConnectionManagerTest {
 
     @Test
     public void testGetConnectionPoolEnabledWithPoolProps() throws SQLException {
-        Driver mockDriver = mock(FakeJdbcDriver.class);
+        Driver mockDriver = FakeJdbcDriver.getMockDriver();
         when(mockDriverManagerWrapper.getDriver("test-url")).thenReturn(mockDriver);
         when(mockDriver.connect(anyString(), any())).thenReturn(mockConnection);
         when(mockDriver.acceptsURL("test-url")).thenReturn(true);
-        DriverManager.registerDriver(mockDriver);
 
         connProps.setProperty("user", "foo");
         connProps.setProperty("password", "foo-password");


### PR DESCRIPTION
https://tracker.yandex.ru/ADBDEV-5823
In jdbc-site.xml, if value for the property “jdbc.driver” is set with unsuitable JDBC driver, but class is present in the libraries and instantiatable, the connection will still be settled with default driver - no warning, no error will be displayed on pxf logs or thrown.