### PR TITLE
ADBDEV-5829 Refactor ListConstToStr function

### DIFF
--- a/external-table/src/pxffilters.c
+++ b/external-table/src/pxffilters.c
@@ -1196,11 +1196,6 @@ scalar_const_to_str(Const *constval, StringInfo buf)
 static void
 list_const_to_str(Const *constval, StringInfo buf)
 {
-	StringInfo	interm_buf;
-	Datum	   *dats;
-	ArrayType  *arr;
-	int			len;
-
 	if (constval->constisnull)
 	{
 		elog(DEBUG1, "Null constant is not expected in this context.");
@@ -1213,10 +1208,6 @@ list_const_to_str(Const *constval, StringInfo buf)
 		return;
 	}
 
-	arr = DatumGetArrayTypeP(constval->constvalue);
-
-	interm_buf = makeStringInfo();
-
 	switch (constval->consttype)
 	{
 		case INT2ARRAYOID:
@@ -1224,11 +1215,19 @@ list_const_to_str(Const *constval, StringInfo buf)
 		case INT8ARRAYOID:
 		case TEXTARRAYOID:
 			{
+				StringInfo	interm_buf;
+				Datum	   *dats;
+				ArrayType  *arr;
+				int			len;
 				Oid			typoutput;
 				bool		typIsVarlena;
 				int16		elmlen;
 				bool		elmbyval;
 				char		elmalign;
+
+				arr = DatumGetArrayTypeP(constval->constvalue);
+
+				interm_buf = makeStringInfo();
 				/*
 				 * Get necessary data for deconstruct_array() and output function
 				 * from the catalog.
@@ -1257,6 +1256,7 @@ list_const_to_str(Const *constval, StringInfo buf)
 					resetStringInfo(interm_buf);
 					pfree(extval);
 				}
+				pfree(interm_buf->data);
 				break;
 			}
 		default:
@@ -1267,8 +1267,6 @@ list_const_to_str(Const *constval, StringInfo buf)
 				 constval->consttype);
 
 	}
-
-	pfree(interm_buf->data);
 }
 
 /*

--- a/external-table/src/pxffilters.c
+++ b/external-table/src/pxffilters.c
@@ -1200,6 +1200,11 @@ list_const_to_str(Const *constval, StringInfo buf)
 	Datum	   *dats;
 	ArrayType  *arr;
 	int			len;
+	Oid			typoutput;
+	bool		typIsVarlena;
+	int16		elmlen;
+	bool		elmbyval;
+	char		elmalign;
 
 	if (constval->constisnull)
 	{
@@ -1217,81 +1222,40 @@ list_const_to_str(Const *constval, StringInfo buf)
 
 	interm_buf = makeStringInfo();
 
+	/*
+	 * Get necessary data for deconstruct_array() and output function
+	 * from the catalog.
+	 */
+	get_typlenbyvalalign(ARR_ELEMTYPE(arr), &elmlen, &elmbyval, &elmalign);
+	deconstruct_array(arr,
+					  ARR_ELEMTYPE(arr),
+					  elmlen,
+					  elmbyval,
+					  elmalign,
+					  &dats,
+					  NULL,
+					  &len);
+
+	getTypeOutputInfo(ARR_ELEMTYPE(arr), &typoutput, &typIsVarlena);
+
 	switch (constval->consttype)
 	{
 		case INT2ARRAYOID:
-			{
-				int16		value;
-
-				deconstruct_array(arr, INT2OID, sizeof(value), true, 's', &dats, NULL, &len);
-
-				for (int i = 0; i < len; i++)
-				{
-					value = DatumGetInt16(dats[i]);
-
-					appendStringInfo(interm_buf, "%hd", value);
-
-					appendStringInfo(buf, "%c%d%c%s",
-									 PXF_SIZE_BYTES, interm_buf->len,
-									 PXF_CONST_DATA, interm_buf->data);
-					resetStringInfo(interm_buf);
-				}
-				break;
-			}
 		case INT4ARRAYOID:
-			{
-				int32		value;
-
-				deconstruct_array(arr, INT4OID, sizeof(value), true, 'i', &dats, NULL, &len);
-
-				for (int i = 0; i < len; i++)
-				{
-					value = DatumGetInt32(dats[i]);
-
-					appendStringInfo(interm_buf, "%d", value);
-
-					appendStringInfo(buf, "%c%d%c%s",
-									 PXF_SIZE_BYTES, interm_buf->len,
-									 PXF_CONST_DATA, interm_buf->data);
-					resetStringInfo(interm_buf);
-				}
-				break;
-			}
 		case INT8ARRAYOID:
-			{
-				int64		value;
-
-				deconstruct_array(arr, INT8OID, sizeof(value), true, 'd', &dats, NULL, &len);
-
-				for (int i = 0; i < len; i++)
-				{
-					value = DatumGetInt64(dats[i]);
-
-					appendStringInfo(interm_buf, "%ld", value);
-
-					appendStringInfo(buf, "%c%d%c%s",
-									 PXF_SIZE_BYTES, interm_buf->len,
-									 PXF_CONST_DATA, interm_buf->data);
-					resetStringInfo(interm_buf);
-				}
-				break;
-			}
 		case TEXTARRAYOID:
 			{
-				char	   *value;
-
-				deconstruct_array(arr, TEXTOID, -1, false, 'i', &dats, NULL, &len);
-
 				for (int i = 0; i < len; i++)
 				{
-					value = DatumGetCString(DirectFunctionCall1(textout, dats[i]));
+					char *extval = OidOutputFunctionCall(typoutput, dats[i]);
 
-					appendStringInfo(interm_buf, "%s", value);
+					appendStringInfo(interm_buf, "%s", extval);
 
 					appendStringInfo(buf, "%c%d%c%s",
 									 PXF_SIZE_BYTES, interm_buf->len,
 									 PXF_CONST_DATA, interm_buf->data);
 					resetStringInfo(interm_buf);
+					pfree(extval);
 				}
 				break;
 			}
@@ -1301,7 +1265,6 @@ list_const_to_str(Const *constval, StringInfo buf)
 				 "internal error in pxffilters.c:list_const_to_str. "
 				 "Using unsupported data type (%d)",
 				 constval->consttype);
-
 	}
 
 	pfree(interm_buf->data);

--- a/external-table/src/pxffilters.c
+++ b/external-table/src/pxffilters.c
@@ -1200,11 +1200,6 @@ list_const_to_str(Const *constval, StringInfo buf)
 	Datum	   *dats;
 	ArrayType  *arr;
 	int			len;
-	Oid			typoutput;
-	bool		typIsVarlena;
-	int16		elmlen;
-	bool		elmbyval;
-	char		elmalign;
 
 	if (constval->constisnull)
 	{
@@ -1229,6 +1224,11 @@ list_const_to_str(Const *constval, StringInfo buf)
 		case INT8ARRAYOID:
 		case TEXTARRAYOID:
 			{
+				Oid			typoutput;
+				bool		typIsVarlena;
+				int16		elmlen;
+				bool		elmbyval;
+				char		elmalign;
 				/*
 				 * Get necessary data for deconstruct_array() and output function
 				 * from the catalog.

--- a/external-table/src/pxffilters.c
+++ b/external-table/src/pxffilters.c
@@ -1222,22 +1222,6 @@ list_const_to_str(Const *constval, StringInfo buf)
 
 	interm_buf = makeStringInfo();
 
-	/*
-	 * Get necessary data for deconstruct_array() and output function
-	 * from the catalog.
-	 */
-	get_typlenbyvalalign(ARR_ELEMTYPE(arr), &elmlen, &elmbyval, &elmalign);
-	deconstruct_array(arr,
-					  ARR_ELEMTYPE(arr),
-					  elmlen,
-					  elmbyval,
-					  elmalign,
-					  &dats,
-					  NULL,
-					  &len);
-
-	getTypeOutputInfo(ARR_ELEMTYPE(arr), &typoutput, &typIsVarlena);
-
 	switch (constval->consttype)
 	{
 		case INT2ARRAYOID:
@@ -1245,6 +1229,22 @@ list_const_to_str(Const *constval, StringInfo buf)
 		case INT8ARRAYOID:
 		case TEXTARRAYOID:
 			{
+				/*
+				 * Get necessary data for deconstruct_array() and output function
+				 * from the catalog.
+				 */
+				get_typlenbyvalalign(ARR_ELEMTYPE(arr), &elmlen, &elmbyval, &elmalign);
+				deconstruct_array(arr,
+								  ARR_ELEMTYPE(arr),
+								  elmlen,
+								  elmbyval,
+								  elmalign,
+								  &dats,
+								  NULL,
+								  &len);
+
+				getTypeOutputInfo(ARR_ELEMTYPE(arr), &typoutput, &typIsVarlena);
+
 				for (int i = 0; i < len; i++)
 				{
 					char *extval = OidOutputFunctionCall(typoutput, dats[i]);
@@ -1265,6 +1265,7 @@ list_const_to_str(Const *constval, StringInfo buf)
 				 "internal error in pxffilters.c:list_const_to_str. "
 				 "Using unsupported data type (%d)",
 				 constval->consttype);
+
 	}
 
 	pfree(interm_buf->data);

--- a/fdw/pxf_filter.c
+++ b/fdw/pxf_filter.c
@@ -1294,6 +1294,11 @@ ListConstToStr(Const *constval, StringInfo buf)
 	Datum	   *dats;
 	ArrayType  *arr;
 	int			len;
+	Oid			typoutput;
+	bool		typIsVarlena;
+	int16		elmlen;
+	bool		elmbyval;
+	char		elmalign;
 
 	if (constval->constisnull)
 	{
@@ -1312,102 +1317,40 @@ ListConstToStr(Const *constval, StringInfo buf)
 
 	interm_buf = makeStringInfo();
 
+	/*
+	 * Get necessary data for deconstruct_array() and out function
+	 * from the catalog.
+	 */
+	get_typlenbyvalalign(ARR_ELEMTYPE(arr), &elmlen, &elmbyval, &elmalign);
+	deconstruct_array(arr,
+					  ARR_ELEMTYPE(arr),
+					  elmlen,
+					  elmbyval,
+					  elmalign,
+					  &dats,
+					  NULL,
+					  &len);
+
+	getTypeOutputInfo(ARR_ELEMTYPE(arr), &typoutput, &typIsVarlena);
+
 	switch (constval->consttype)
 	{
 		case INT2ARRAYOID:
-			{
-				int16		value;
-
-				deconstruct_array(arr,
-								  INT2OID,
-								  sizeof(value),
-								  true,
-								  's',
-								  &dats,
-								  NULL,
-								  &len);
-
-				for (int i = 0; i < len; i++)
-				{
-					value = DatumGetInt16(dats[i]);
-
-					appendStringInfo(interm_buf, "%hd", value);
-
-					appendStringInfo(buf, "%c%d%c%s",
-									 PXF_SIZE_BYTES, interm_buf->len,
-									 PXF_CONST_DATA, interm_buf->data);
-					resetStringInfo(interm_buf);
-				}
-				break;
-			}
 		case INT4ARRAYOID:
-			{
-				int32		value;
-
-				deconstruct_array(arr,
-								  INT4OID,
-								  sizeof(value),
-								  true,
-								  'i',
-								  &dats,
-								  NULL,
-								  &len);
-
-				for (int i = 0; i < len; i++)
-				{
-					value = DatumGetInt32(dats[i]);
-
-					appendStringInfo(interm_buf, "%d", value);
-
-					appendStringInfo(buf, "%c%d%c%s",
-									 PXF_SIZE_BYTES, interm_buf->len,
-									 PXF_CONST_DATA, interm_buf->data);
-					resetStringInfo(interm_buf);
-				}
-				break;
-			}
 		case INT8ARRAYOID:
-			{
-				int64		value;
-
-				deconstruct_array(arr,
-								  INT8OID,
-								  sizeof(value),
-								  true,
-								  'd',
-								  &dats,
-								  NULL,
-								  &len);
-
-				for (int i = 0; i < len; i++)
-				{
-					value = DatumGetInt64(dats[i]);
-
-					appendStringInfo(interm_buf, "%ld", value);
-
-					appendStringInfo(buf, "%c%d%c%s",
-									 PXF_SIZE_BYTES, interm_buf->len,
-									 PXF_CONST_DATA, interm_buf->data);
-					resetStringInfo(interm_buf);
-				}
-				break;
-			}
 		case TEXTARRAYOID:
 			{
-				char	   *value;
-
-				deconstruct_array(arr, TEXTOID, -1, false, 'i', &dats, NULL, &len);
-
 				for (int i = 0; i < len; i++)
 				{
-					value = DatumGetCString(DirectFunctionCall1(textout, dats[i]));
+					char *extval = OidOutputFunctionCall(typoutput, dats[i]);
 
-					appendStringInfo(interm_buf, "%s", value);
+					appendStringInfo(interm_buf, "%s", extval);
 
 					appendStringInfo(buf, "%c%d%c%s",
 									 PXF_SIZE_BYTES, interm_buf->len,
 									 PXF_CONST_DATA, interm_buf->data);
 					resetStringInfo(interm_buf);
+					pfree(extval);
 				}
 				break;
 			}

--- a/fdw/pxf_filter.c
+++ b/fdw/pxf_filter.c
@@ -1294,11 +1294,6 @@ ListConstToStr(Const *constval, StringInfo buf)
 	Datum	   *dats;
 	ArrayType  *arr;
 	int			len;
-	Oid			typoutput;
-	bool		typIsVarlena;
-	int16		elmlen;
-	bool		elmbyval;
-	char		elmalign;
 
 	if (constval->constisnull)
 	{
@@ -1317,22 +1312,6 @@ ListConstToStr(Const *constval, StringInfo buf)
 
 	interm_buf = makeStringInfo();
 
-	/*
-	 * Get necessary data for deconstruct_array() and out function
-	 * from the catalog.
-	 */
-	get_typlenbyvalalign(ARR_ELEMTYPE(arr), &elmlen, &elmbyval, &elmalign);
-	deconstruct_array(arr,
-					  ARR_ELEMTYPE(arr),
-					  elmlen,
-					  elmbyval,
-					  elmalign,
-					  &dats,
-					  NULL,
-					  &len);
-
-	getTypeOutputInfo(ARR_ELEMTYPE(arr), &typoutput, &typIsVarlena);
-
 	switch (constval->consttype)
 	{
 		case INT2ARRAYOID:
@@ -1340,6 +1319,27 @@ ListConstToStr(Const *constval, StringInfo buf)
 		case INT8ARRAYOID:
 		case TEXTARRAYOID:
 			{
+				Oid			typoutput;
+				bool		typIsVarlena;
+				int16		elmlen;
+				bool		elmbyval;
+				char		elmalign;
+				/*
+				 * Get necessary data for deconstruct_array() and out function
+				 * from the catalog.
+				 */
+				get_typlenbyvalalign(ARR_ELEMTYPE(arr), &elmlen, &elmbyval, &elmalign);
+				deconstruct_array(arr,
+								  ARR_ELEMTYPE(arr),
+								  elmlen,
+								  elmbyval,
+								  elmalign,
+								  &dats,
+								  NULL,
+								  &len);
+
+				getTypeOutputInfo(ARR_ELEMTYPE(arr), &typoutput, &typIsVarlena);
+
 				for (int i = 0; i < len; i++)
 				{
 					char *extval = OidOutputFunctionCall(typoutput, dats[i]);

--- a/fdw/pxf_filter.c
+++ b/fdw/pxf_filter.c
@@ -1290,11 +1290,6 @@ ScalarConstToStr(Const *constval, StringInfo buf)
 static void
 ListConstToStr(Const *constval, StringInfo buf)
 {
-	StringInfo	interm_buf;
-	Datum	   *dats;
-	ArrayType  *arr;
-	int			len;
-
 	if (constval->constisnull)
 	{
 		elog(DEBUG1, "Null constant is not expected in this context.");
@@ -1308,10 +1303,6 @@ ListConstToStr(Const *constval, StringInfo buf)
 		return;
 	}
 
-	arr = DatumGetArrayTypeP(constval->constvalue);
-
-	interm_buf = makeStringInfo();
-
 	switch (constval->consttype)
 	{
 		case INT2ARRAYOID:
@@ -1319,13 +1310,21 @@ ListConstToStr(Const *constval, StringInfo buf)
 		case INT8ARRAYOID:
 		case TEXTARRAYOID:
 			{
+				StringInfo	interm_buf;
+				Datum	   *dats;
+				ArrayType  *arr;
+				int			len;
 				Oid			typoutput;
 				bool		typIsVarlena;
 				int16		elmlen;
 				bool		elmbyval;
 				char		elmalign;
+
+				arr = DatumGetArrayTypeP(constval->constvalue);
+
+				interm_buf = makeStringInfo();
 				/*
-				 * Get necessary data for deconstruct_array() and out function
+				 * Get necessary data for deconstruct_array() and output function
 				 * from the catalog.
 				 */
 				get_typlenbyvalalign(ARR_ELEMTYPE(arr), &elmlen, &elmbyval, &elmalign);
@@ -1352,6 +1351,7 @@ ListConstToStr(Const *constval, StringInfo buf)
 					resetStringInfo(interm_buf);
 					pfree(extval);
 				}
+				pfree(interm_buf->data);
 				break;
 			}
 		default:
@@ -1362,8 +1362,6 @@ ListConstToStr(Const *constval, StringInfo buf)
 				 constval->consttype);
 
 	}
-
-	pfree(interm_buf->data);
 }
 
 /*


### PR DESCRIPTION
The original implementation of the list_const_to_str (ListConstToStr) function
was intended to extract and format values from array constants into a string
buffer, supporting data types like int2[], int4[], int8[], and text[]. It
checked for null constants, logged exceptions, extracted the array, processed
each supported type with specific code blocks to deconstruct the array,
converted each element to a string, and appended the formatted data to a buffer.
However, the approach led to code duplication, maintenance challenges, and
reduced readability due to scattered, repetitive logic.

The refactored function consolidated common logic into reusable, unified steps.
It retrieves type information and deconstructs arrays using a single,
generalized procedure, eliminating repetitive code. This streamlined array
processing is supported by getTypeOutputInfo, which extracts output function
from the catalog, facilitating consistent conversion across all data types
with OidOutputFunctionCall.

Additionally, the refactored function simplifies its logic by centralizing the
handling of array elements and reducing the switch case complexity. This
enhances readability and maintainability, making it easier to understand and
modify. Adding new array types now involves minimal changes, creating a more
elegant, less error-prone codebase.

----
### How to test with jdbc:
With external table:
1. create jdbc profile in $PXF_BASE/conf/pxf-profiles.xml
<details>
  <summary>Ex</summary>

 ```

<?xml version='1.0' encoding='UTF-8'?>
<profiles>
  <profile>
    <name>JDBC</name>
    <description>jdbc</description>
    <plugins>
      <fragmenter>org.greenplum.pxf.plugins.jdbc.JdbcPartitionFragmenter</fragmenter>
      <accessor>org.greenplum.pxf.plugins.jdbc.JdbcAccessor</accessor>
      <resolver>org.greenplum.pxf.plugins.jdbc.JdbcResolver</resolver>
    </plugins>
    </profile>
</profiles>

``` 
 
</details>
2. create server configuration in $PXF_BASE/servers/postgresql/jdbc-site.xml
<details>
  <summary>Ex</summary>

 ```
<?xml version="1.0" encoding="UTF-8"?>
<configuration>
    <property>
        <name>jdbc.driver</name>
        <value>org.postgresql.Driver</value>
        <description>Class name of the JDBC driver (e.g. org.postgresql.Driver)</description>
    </property>
    <property>
        <name>jdbc.url</name>
        <value>jdbc:postgresql://localhost:5432/postgres</value>
        <description>The URL that the JDBC driver can use to connect to the database (e.g. jdbc:postgresql://localhost/postgres)</description>
    </property>
    <property>
        <name>jdbc.user</name>
        <value>bimbo</value>
        <description>User name for connecting to the database (e.g. postgres)</description>
    </property>
</configuration>

``` 
</details>

3.
```
create extension pxf;
CREATE readable EXTERNAL TABLE test_int2(i int2)
     LOCATION ('pxf://public.test_int2?PROFILE=JDBC&SERVER=postgresql')
          FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');

select * from test_int2 where i in (1::int2, 3::int2);
select * from test_int4 where i in (1, 3);
select * from test_int8 where i in (1::int8, 3::int8);
select * from test_text where i in ('asdasdas'::text, 'tsadasd'::text);
```
With fdw:
1. Create configuration:
<details>
  <summary>Ex</summary>

 ```
CREATE SERVER postgresql_server
     FOREIGN DATA WRAPPER jdbc_pxf_fdw
          OPTIONS ( 
         jdbc_driver 'org.postgresql.Driver', 
         db_url 'jdbc:postgresql://localhost:5432/postgres',
          batch_size '10000',
         fetch_size '2000'
     );
     
     
 CREATE USER MAPPING FOR my_user
     SERVER postgresql_server
     OPTIONS ( user 'pg_user');

``` 
 
</details>

2. The same queries:
```
           CREATE FOREIGN TABLE test_text_fdw(t text)
          SERVER postgresql_server
          OPTIONS ( resource 'public.test_text');

select * from test_text_fdw where i in ('asdasdas'::text, 'tsadasd'::text);
```
And then just look at pxf-service.log or [here](https://github.com/arenadata/pxf/blob/103d3008fa6a1f02ec4b2bc47e9ffe242822558b/external-table/src/pxfheaders.c#L211)