### PR TITLE
Fix pip installation after CentOS 7 EOL

### DIFF
--- a/automation/arenadata/Dockerfile
+++ b/automation/arenadata/Dockerfile
@@ -1,5 +1,22 @@
 FROM hub.adsw.io/library/gpdb6_regress:latest
-RUN sudo yum install -y epel-release  python-pip
+
+ARG CENTOS_REPOS_URL="https://mirror.axelname.ru/centos"
+
+# Change URL for repos, because Centos 7 EOL 30.06.2024
+RUN if [[ "x86_64" == "$(uname -i)" ]]; then \
+        sed -i "s|mirrorlist=http://mirrorlist.centos.org/?release=\$releasever\&arch=\$basearch\&repo=os\&infra=\$infra|baseurl=$CENTOS_REPOS_URL/\$releasever/os/\$basearch|g" /etc/yum.repos.d/CentOS-Base.repo; \
+        sed -i "s|mirrorlist=http://mirrorlist.centos.org/?release=\$releasever\&arch=\$basearch\&repo=updates\&infra=\$infra|baseurl=$CENTOS_REPOS_URL/\$releasever/updates/\$basearch|g" /etc/yum.repos.d/CentOS-Base.repo; \
+        sed -i "s|mirrorlist=http://mirrorlist.centos.org/?release=\$releasever\&arch=\$basearch\&repo=extras\&infra=\$infra|baseurl=$CENTOS_REPOS_URL/\$releasever/extras/\$basearch|g" /etc/yum.repos.d/CentOS-Base.repo; \
+        sed -i "s|mirrorlist=http://mirrorlist.centos.org?arch=\$basearch\&release=7\&repo=sclo-rh|baseurl=$CENTOS_REPOS_URL/\$releasever/sclo/\$basearch/rh/|g" /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo; \
+        sed -i "s|mirrorlist=http://mirrorlist.centos.org?arch=\$basearch\&release=7\&repo=sclo-sclo|baseurl=$CENTOS_REPOS_URL/\$releasever/sclo/\$basearch/sclo/|g" /etc/yum.repos.d/CentOS-SCLo-scl.repo; \
+    else \
+        sed -i "s|mirrorlist=http://mirrorlist.centos.org/?release=\$releasever\&arch=\$basearch\&repo=os\&infra=\$infra|baseurl=$CENTOS_REPOS_URL/altarch/\$releasever/os/\$basearch|g" /etc/yum.repos.d/CentOS-Base.repo; \
+        sed -i "s|mirrorlist=http://mirrorlist.centos.org/?release=\$releasever\&arch=\$basearch\&repo=updates\&infra=\$infra|baseurl=$CENTOS_REPOS_URL/altarch/\$releasever/updates/\$basearch|g" /etc/yum.repos.d/CentOS-Base.repo; \
+        sed -i "s|mirrorlist=http://mirrorlist.centos.org/?release=\$releasever\&arch=\$basearch\&repo=extras\&infra=\$infra|baseurl=$CENTOS_REPOS_URL/altarch/\$releasever/extras/\$basearch|g" /etc/yum.repos.d/CentOS-Base.repo; \
+        sed -i "s|mirrorlist=http://mirrorlist.centos.org?arch=\$basearch\&release=7\&repo=sclo-rh|baseurl=$CENTOS_REPOS_URL/altarch/\$releasever/sclo/\$basearch/rh/|g" /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo; \
+        sed -i "s|mirrorlist=http://mirrorlist.centos.org?arch=\$basearch\&release=7\&repo=sclo-sclo|baseurl=$CENTOS_REPOS_URL/altarch/\$releasever/sclo/\$basearch/sclo/|g" /etc/yum.repos.d/CentOS-SCLo-scl.repo; \
+    fi && \
+    yum install -y python-paramiko
 
 # install maven
 RUN wget --no-check-certificate https://dlcdn.apache.org/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz -P /tmp \
@@ -63,7 +80,6 @@ RUN mkdir workspace && ln -s /home/gpadmin/pxf_src /home/gpadmin/workspace/pxf &
 
 # Need to run automation tests
 ENV PXF_HOME=/usr/local/greenplum-db-devel/pxf
-RUN sudo -H -u gpadmin bash -c "pip install --user paramiko"
 RUN localedef -c -i ru_RU -f CP1251 ru_RU.CP1251
 RUN cp ${PXF_HOME}/templates/*-site.xml ${PXF_HOME}/servers/default/
 

--- a/fdw/expected/pxf_fdw_foreign_table.out
+++ b/fdw/expected/pxf_fdw_foreign_table.out
@@ -28,7 +28,7 @@ ERROR:  the resource option must be defined at the foreign table level
 --
 -- Table creation fails if config option is provided
 --
-CREATE FOREIGN TABLE pxf_fdw_test_table ()
+CREATE FOREIGN TABLE pxf_fdw_test_table (id int, name text)
     SERVER pxf_fdw_test_server
     OPTIONS ( config '/foo/bar' );
 ERROR:  the config option can only be defined at the pg_foreign_server level
@@ -162,14 +162,14 @@ ERROR:  log_errors requires a Boolean value
 --
 -- Table creation fails if quote is provided (CSV-only option)
 --
-CREATE FOREIGN TABLE pxf_fdw_test_table_csv_only ()
+CREATE FOREIGN TABLE pxf_fdw_test_table_csv_only (id int, name text)
     SERVER pxf_fdw_test_server
     OPTIONS ( resource '/foo', quote '9' );
 ERROR:  quote available only in CSV mode
 --
 -- Table creation fails if disable_ppd is non-boolean
 --
-CREATE FOREIGN TABLE pxf_fdw_test_table_disable_ppd ()
+CREATE FOREIGN TABLE pxf_fdw_test_table_disable_ppd (id int, name text)
     SERVER pxf_fdw_test_server
     OPTIONS ( resource '/ppd', disable_ppd '6' );
 ERROR:  disable_ppd requires a Boolean value

--- a/fdw/sql/pxf_fdw_foreign_table.sql
+++ b/fdw/sql/pxf_fdw_foreign_table.sql
@@ -29,7 +29,7 @@ CREATE FOREIGN TABLE pxf_fdw_test_table (id int, name text)
 --
 -- Table creation fails if config option is provided
 --
-CREATE FOREIGN TABLE pxf_fdw_test_table ()
+CREATE FOREIGN TABLE pxf_fdw_test_table (id int, name text)
     SERVER pxf_fdw_test_server
     OPTIONS ( config '/foo/bar' );
 
@@ -174,14 +174,14 @@ CREATE FOREIGN TABLE pxf_fdw_test_table_log_errors (id int, name text)
 --
 -- Table creation fails if quote is provided (CSV-only option)
 --
-CREATE FOREIGN TABLE pxf_fdw_test_table_csv_only ()
+CREATE FOREIGN TABLE pxf_fdw_test_table_csv_only (id int, name text)
     SERVER pxf_fdw_test_server
     OPTIONS ( resource '/foo', quote '9' );
 
 --
 -- Table creation fails if disable_ppd is non-boolean
 --
-CREATE FOREIGN TABLE pxf_fdw_test_table_disable_ppd ()
+CREATE FOREIGN TABLE pxf_fdw_test_table_disable_ppd (id int, name text)
     SERVER pxf_fdw_test_server
     OPTIONS ( resource '/ppd', disable_ppd '6' );
 


### PR DESCRIPTION
Fix pip installation after CentOS 7 EOL

CentOS Linux 7 reached end of life (EOL) on June 30, 2024.
Approach for installing paramiko was changed to installation from the
yum install python-paramiko instead of pip install paramiko.

##

Fix PXF regression tests (#108)

The 669d593f5047408bba143cdd06364e6d03937230 commit appeared in GPDB 6.27.1.
This commit adds warning message if user tries to create a table with no
columns.

The pxf_fdw_foreign_table regression test used such tables. This patch adds
columns to these tables.