### PR TITLE
ADBDEV-5949: Fix IntelliJ IDEA inspection report: General

### DIFF
--- a/automation/src/main/java/org/greenplum/pxf/automation/components/oracle/Oracle.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/components/oracle/Oracle.java
@@ -48,23 +48,6 @@ public class Oracle extends DbSystemObject {
     }
 
     @Override
-    public void createTableAndVerify(Table table) throws Exception {
-        ReportUtils.startLevel(report, getClass(), "Create and Verify Table: " + table.getFullName());
-        try {
-            dropTable(table, true);
-            createTable(table);
-        } catch (Exception e) {
-            ReportUtils.stopLevel(report);
-            throw e;
-        }
-        if (!checkTableExists(table)) {
-            ReportUtils.stopLevel(report);
-            throw new Exception("Table " + table.getName() + " do not exists");
-        }
-        ReportUtils.stopLevel(report);
-    }
-
-    @Override
     public void dropTable(Table table, boolean cascade) throws Exception {
         String queryDropTable = "DROP TABLE " + table.getSchema() + "." + table.getName();
         runQuery(queryDropTable, true, false);

--- a/automation/src/main/java/org/greenplum/pxf/automation/datapreparer/CustomTextPreparer.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/datapreparer/CustomTextPreparer.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
+import java.util.stream.IntStream;
 
 import org.greenplum.pxf.automation.fileformats.IDataPreparer;
 import org.greenplum.pxf.automation.structures.tables.basic.Table;
@@ -23,8 +24,6 @@ public class CustomTextPreparer implements IDataPreparer {
 
         // fill data and dataTable with data according to given rows
         for (int i = 0, num1 = 1; i < rows; i++, num1++) {
-
-            ArrayList<String> row = new ArrayList<String>();
 
             // create calendar and set timestamp as milliseconds
             Calendar calendar = new GregorianCalendar();
@@ -48,33 +47,30 @@ public class CustomTextPreparer implements IDataPreparer {
             // get timestamp value from SimpleDateFormat
             String timeStampValue = dateFormat.format(calendar.getTime());
 
-            row.add("s_" + num1);
-            row.add("s_" + num1 * 10);
-            row.add("s_" + num1 * 100);
-            row.add(timeStampValue);
-            row.add(String.valueOf(num1));
-            row.add(String.valueOf(num1 * 10));
-            row.add(String.valueOf(num1 * 100));
-            row.add(String.valueOf(num1 * 100));
-            row.add(String.valueOf(num1 * 100));
-            row.add(String.valueOf(num1 * 100));
-            row.add(String.valueOf(num1 * 100));
-            row.add("s_" + num1);
-            row.add("s_" + num1 * 10);
-            row.add("s_" + num1 * 100);
-            row.add(timeStampValue);
-            row.add(String.valueOf(num1));
-            row.add(String.valueOf(num1 * 10));
-            row.add(String.valueOf(num1 * 100));
-            row.add(String.valueOf(num1 * 100));
-            row.add(String.valueOf(num1 * 100));
-            row.add(String.valueOf(num1 * 100));
-            row.add(String.valueOf(num1 * 100));
+            ArrayList<String> row = fillData(num1, timeStampValue);
 
             dataTable.addRow(row);
             data[i] = row;
         }
 
         return data;
+    }
+
+    private ArrayList<String> fillData(final int num1, final String timeStampValue) {
+        ArrayList<String> rows = new ArrayList<>();
+        IntStream.rangeClosed(0, 1).forEach(i -> {
+            rows.add("s_" + num1);
+            rows.add("s_" + num1 * 10);
+            rows.add("s_" + num1 * 100);
+            rows.add(timeStampValue);
+            rows.add(String.valueOf(num1));
+            rows.add(String.valueOf(num1 * 10));
+            rows.add(String.valueOf(num1 * 100));
+            rows.add(String.valueOf(num1 * 100));
+            rows.add(String.valueOf(num1 * 100));
+            rows.add(String.valueOf(num1 * 100));
+            rows.add(String.valueOf(num1 * 100));
+        });
+        return rows;
     }
 }

--- a/automation/src/main/java/org/greenplum/pxf/automation/datapreparer/CustomTextPreparer.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/datapreparer/CustomTextPreparer.java
@@ -4,6 +4,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
+import java.util.List;
 import java.util.TimeZone;
 import java.util.stream.IntStream;
 
@@ -47,7 +48,7 @@ public class CustomTextPreparer implements IDataPreparer {
             // get timestamp value from SimpleDateFormat
             String timeStampValue = dateFormat.format(calendar.getTime());
 
-            ArrayList<String> row = fillData(num1, timeStampValue);
+            List<String> row = fillData(num1, timeStampValue);
 
             dataTable.addRow(row);
             data[i] = row;
@@ -56,8 +57,8 @@ public class CustomTextPreparer implements IDataPreparer {
         return data;
     }
 
-    private ArrayList<String> fillData(final int num1, final String timeStampValue) {
-        ArrayList<String> rows = new ArrayList<>();
+    private List<String> fillData(final int num1, final String timeStampValue) {
+        List<String> rows = new ArrayList<>();
         IntStream.rangeClosed(0, 1).forEach(i -> {
             rows.add("s_" + num1);
             rows.add("s_" + num1 * 10);

--- a/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/basic/Table.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/basic/Table.java
@@ -159,7 +159,7 @@ public class Table {
      */
     public void addRow(List<String> row) {
         if (data == null) {
-            data = new ArrayList<List<String>>();
+            data = new ArrayList<>();
         }
 
         data.add(row);

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/orc/ORCVectorizedMappingFunctions.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/orc/ORCVectorizedMappingFunctions.java
@@ -425,7 +425,6 @@ class ORCVectorizedMappingFunctions {
     }
 
     // DateWritable is no longer deprecated in newer versions of storage api ¯\_(ツ)_/¯
-    @SuppressWarnings("deprecation")
     public static OneField[] dateReader(VectorizedRowBatch batch, ColumnVector columnVector, Integer oid) {
         LongColumnVector lcv = (LongColumnVector) columnVector;
         if (lcv == null)

--- a/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveColumnarSerdeResolver.java
+++ b/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveColumnarSerdeResolver.java
@@ -20,8 +20,6 @@ package org.greenplum.pxf.plugins.hive;
  */
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.hadoop.hive.common.type.HiveDecimal;
-import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.StructField;
@@ -48,8 +46,6 @@ import org.greenplum.pxf.api.model.RequestContext;
 import org.greenplum.pxf.api.utilities.ColumnDescriptor;
 import org.greenplum.pxf.api.utilities.Utilities;
 
-import java.sql.Date;
-import java.sql.Timestamp;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -205,55 +201,7 @@ public class HiveColumnarSerdeResolver extends HiveResolver {
         if (!firstColumn) {
             builder.append(delimiter);
         }
-
-        if (isDefaultPartition(type, val)) {
-            builder.append(nullChar);
-        } else {
-            // ignore the type's parameters
-            String typeName = type.replaceAll("\\(.*\\)", "");
-            switch (typeName) {
-                case serdeConstants.STRING_TYPE_NAME:
-                case serdeConstants.VARCHAR_TYPE_NAME:
-                case serdeConstants.CHAR_TYPE_NAME:
-                    builder.append(val);
-                    break;
-                case serdeConstants.BOOLEAN_TYPE_NAME:
-                    builder.append(Boolean.parseBoolean(val));
-                    break;
-                case serdeConstants.TINYINT_TYPE_NAME:
-                case serdeConstants.SMALLINT_TYPE_NAME:
-                    builder.append(Short.parseShort(val));
-                    break;
-                case serdeConstants.INT_TYPE_NAME:
-                    builder.append(Integer.parseInt(val));
-                    break;
-                case serdeConstants.BIGINT_TYPE_NAME:
-                    builder.append(Long.parseLong(val));
-                    break;
-                case serdeConstants.FLOAT_TYPE_NAME:
-                    builder.append(Float.parseFloat(val));
-                    break;
-                case serdeConstants.DOUBLE_TYPE_NAME:
-                    builder.append(Double.parseDouble(val));
-                    break;
-                case serdeConstants.TIMESTAMP_TYPE_NAME:
-                    builder.append(Timestamp.valueOf(val));
-                    break;
-                case serdeConstants.DATE_TYPE_NAME:
-                    builder.append(Date.valueOf(val));
-                    break;
-                case serdeConstants.DECIMAL_TYPE_NAME:
-                    builder.append(HiveDecimal.create(val).bigDecimalValue());
-                    break;
-                case serdeConstants.BINARY_TYPE_NAME:
-                    Utilities.byteArrayToOctalString(val.getBytes(), builder);
-                    break;
-                default:
-                    throw new UnsupportedTypeException(
-                            "Unsupported partition type: " + type);
-            }
-        }
-
+        appendPartition(builder, type, val);
         firstColumn = false;
     }
 

--- a/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveResolver.java
+++ b/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveResolver.java
@@ -299,55 +299,59 @@ public class HiveResolver extends BasePlugin implements Resolver {
             String type = partition.getType();
             String val = partition.getValue();
             parts.append(delimiter);
-            if (isDefaultPartition(type, val)) {
-                parts.append(nullChar);
-            } else {
-                // ignore the type's parameters
-                String typeName = type.replaceAll("\\(.*\\)", "");
-                switch (typeName) {
-                    case serdeConstants.STRING_TYPE_NAME:
-                    case serdeConstants.VARCHAR_TYPE_NAME:
-                    case serdeConstants.CHAR_TYPE_NAME:
-                        parts.append(val);
-                        break;
-                    case serdeConstants.BOOLEAN_TYPE_NAME:
-                        parts.append(Boolean.parseBoolean(val));
-                        break;
-                    case serdeConstants.TINYINT_TYPE_NAME:
-                    case serdeConstants.SMALLINT_TYPE_NAME:
-                        parts.append(Short.parseShort(val));
-                        break;
-                    case serdeConstants.INT_TYPE_NAME:
-                        parts.append(Integer.parseInt(val));
-                        break;
-                    case serdeConstants.BIGINT_TYPE_NAME:
-                        parts.append(Long.parseLong(val));
-                        break;
-                    case serdeConstants.FLOAT_TYPE_NAME:
-                        parts.append(Float.parseFloat(val));
-                        break;
-                    case serdeConstants.DOUBLE_TYPE_NAME:
-                        parts.append(Double.parseDouble(val));
-                        break;
-                    case serdeConstants.TIMESTAMP_TYPE_NAME:
-                        parts.append(Timestamp.valueOf(val));
-                        break;
-                    case serdeConstants.DATE_TYPE_NAME:
-                        parts.append(Date.valueOf(val));
-                        break;
-                    case serdeConstants.DECIMAL_TYPE_NAME:
-                        parts.append(HiveDecimal.create(val).bigDecimalValue());
-                        break;
-                    case serdeConstants.BINARY_TYPE_NAME:
-                        Utilities.byteArrayToOctalString(val.getBytes(), parts);
-                        break;
-                    default:
-                        throw new UnsupportedTypeException(
-                                "Unsupported partition type: " + type);
-                }
-            }
+            appendPartition(parts, type, val);
         }
         this.numberOfPartitions = hivePartitionList.size();
+    }
+
+    void appendPartition(StringBuilder parts, String type, String val) {
+        if (isDefaultPartition(type, val)) {
+            parts.append(nullChar);
+        } else {
+            // ignore the type's parameters
+            String typeName = type.replaceAll("\\(.*\\)", "");
+            switch (typeName) {
+                case serdeConstants.STRING_TYPE_NAME:
+                case serdeConstants.VARCHAR_TYPE_NAME:
+                case serdeConstants.CHAR_TYPE_NAME:
+                    parts.append(val);
+                    break;
+                case serdeConstants.BOOLEAN_TYPE_NAME:
+                    parts.append(Boolean.parseBoolean(val));
+                    break;
+                case serdeConstants.TINYINT_TYPE_NAME:
+                case serdeConstants.SMALLINT_TYPE_NAME:
+                    parts.append(Short.parseShort(val));
+                    break;
+                case serdeConstants.INT_TYPE_NAME:
+                    parts.append(Integer.parseInt(val));
+                    break;
+                case serdeConstants.BIGINT_TYPE_NAME:
+                    parts.append(Long.parseLong(val));
+                    break;
+                case serdeConstants.FLOAT_TYPE_NAME:
+                    parts.append(Float.parseFloat(val));
+                    break;
+                case serdeConstants.DOUBLE_TYPE_NAME:
+                    parts.append(Double.parseDouble(val));
+                    break;
+                case serdeConstants.TIMESTAMP_TYPE_NAME:
+                    parts.append(Timestamp.valueOf(val));
+                    break;
+                case serdeConstants.DATE_TYPE_NAME:
+                    parts.append(Date.valueOf(val));
+                    break;
+                case serdeConstants.DECIMAL_TYPE_NAME:
+                    parts.append(HiveDecimal.create(val).bigDecimalValue());
+                    break;
+                case serdeConstants.BINARY_TYPE_NAME:
+                    Utilities.byteArrayToOctalString(val.getBytes(), parts);
+                    break;
+                default:
+                    throw new UnsupportedTypeException(
+                            "Unsupported partition type: " + type);
+            }
+        }
     }
 
     /**

--- a/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveMetastoreCompatibilityTest.java
+++ b/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveMetastoreCompatibilityTest.java
@@ -40,7 +40,6 @@ public class HiveMetastoreCompatibilityTest {
     private Map<String, String> hiveTableParameters;
 
     @BeforeEach
-    @SuppressWarnings("unchecked")
     public void setup() throws MetaException {
         mockThriftClient = mock(ThriftHiveMetastore.Client.class);
         hiveClientFactory = new HiveClientWrapper.HiveClientFactory();


### PR DESCRIPTION
Fixed errors and warnings that are connected with **General** report:

- Duplicated code fragment
- Redundant suppression

The following warnings have not been fixed: 

**Duplicated code fragment**

`HiveDataFragmenterWithFilter` and `HiveInputFormatFragmenterWithFilter` -  are classes from pxf-automation package. They are used as test fragmenter classes. During the running tests the class files are physically copping to the runtime path to apply the fragmenters. So, we don’t need to remove duplicates and left as is.  

There are 2 classes still have duplicate code (`HiveORCVectorizedResolver` and `ORCVectorizedMappingFunctions`), but I think they need refactoring like we did with parquet.  

**Redundant suppression**

For some reason, the IDE doesn’t  see that  `HiveMetaStoreClientCompatibility1xx` extends the `HiveMetaStoreClient` (in hive-metastore package )which uses deprecated method.  As we are going to bump the hadoop ecosystem libs version as a part of the other task, this issue might be resolved there.