### PR TITLE
ADBDEV-6047: Fix pxf tests on Ubuntu-based image

### DIFF
--- a/arenadata/Dockerfile
+++ b/arenadata/Dockerfile
@@ -1,7 +1,5 @@
-FROM hub.adsw.io/library/gpdb6_regress:adb-6.x-dev as base
-
-# Update epel repo
-RUN yum-config-manager --disable epel && yum-config-manager --add-repo 'http://archives.fedoraproject.org/pub/archive/epel/7/$basearch'
+ARG GPDB_IMAGE=hub.adsw.io/library/gpdb6_regress:adb-6.x-dev
+FROM $GPDB_IMAGE as base
 
 # install go, ginkgo and keep env variables which may be used as a part of base image
 RUN set -eux; \
@@ -22,6 +20,12 @@ RUN set -eux; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \
          exit 1; \
+         ;; \
+    esac; \
+    . /etc/os-release; \
+    case "$ID" in \
+       centos*) \
+         yum-config-manager --disable epel && yum-config-manager --add-repo 'http://archives.fedoraproject.org/pub/archive/epel/7/$basearch'; \
          ;; \
     esac;
 ENV GOPATH=$HOME/go
@@ -44,6 +48,8 @@ WORKDIR /tmp/build
 # create separate image with files we don't want to keep in base image
 FROM base as build
 COPY . /tmp/build/pxf_src
+ENV JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
+SHELL ["bash", "-c"]
 RUN source gpdb_src/concourse/scripts/common.bash && \
     install_gpdb && \
     source '/usr/local/greenplum-db-devel/greenplum_path.sh' && \

--- a/automation/arenadata/Dockerfile
+++ b/automation/arenadata/Dockerfile
@@ -39,7 +39,7 @@ RUN set -eux; \
          yum-config-manager --disable epel && yum-config-manager --add-repo 'http://archives.fedoraproject.org/pub/archive/epel/7/$basearch'; \
          ;; \
        ubuntu*) \
-         apt install -y unzip; \
+         apt install -y unzip vim nano; \
          ;; \
     esac;
 ENV GOPATH=$HOME/go
@@ -76,6 +76,19 @@ RUN mkdir workspace && ln -s /home/gpadmin/pxf_src /home/gpadmin/workspace/pxf &
 ENV PXF_HOME=/usr/local/greenplum-db-devel/pxf
 RUN localedef -c -i ru_RU -f CP1251 ru_RU.CP1251
 RUN cp ${PXF_HOME}/templates/*-site.xml ${PXF_HOME}/servers/default/
+
+# Need to change ssh key to RSA for automation tests with Ubuntu
+RUN set -eux; \
+    . /etc/os-release; \
+        case "$ID" in \
+           ubuntu*) \
+             bash -c 'ssh-keygen -p -P "" -N "" -m pem -f /home/gpadmin/.ssh/id_rsa'; \
+             bash -c 'ssh-keygen -p -P "" -N "" -m pem -f /root/.ssh/id_rsa'; \
+             bash -c 'echo "KexAlgorithms +diffie-hellman-group-exchange-sha1" >> /etc/ssh/sshd_config'; \
+             bash -c 'echo "PubkeyAcceptedAlgorithms +ssh-rsa" >> /etc/ssh/sshd_config'; \
+             bash -c 'echo "HostKeyAlgorithms +ssh-rsa" >> /etc/ssh/sshd_config'; \
+             ;; \
+        esac;
 
 # Move libs to the destination folder
 RUN cp /tmp/libs/* ${PXF_HOME}/lib/

--- a/automation/arenadata/Dockerfile
+++ b/automation/arenadata/Dockerfile
@@ -40,6 +40,7 @@ RUN set -eux; \
          ;; \
        ubuntu*) \
          apt install -y unzip vim nano; \
+         update-locale LANG=en_US.UTF-8; \
          ;; \
     esac;
 ENV GOPATH=$HOME/go

--- a/automation/arenadata/Dockerfile
+++ b/automation/arenadata/Dockerfile
@@ -1,7 +1,5 @@
-FROM hub.adsw.io/library/gpdb6_regress:adb-6.x-dev
-
-# Update epel repo
-RUN yum-config-manager --disable epel && yum-config-manager --add-repo 'http://archives.fedoraproject.org/pub/archive/epel/7/$basearch'
+ARG GPDB_IMAGE=hub.adsw.io/library/gpdb6_regress:adb-6.x-dev
+FROM $GPDB_IMAGE
 
 # install maven
 RUN curl -fSL https://dlcdn.apache.org/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz -o /tmp/apache-maven-3.9.6-bin.tar.gz \
@@ -34,11 +32,21 @@ RUN set -eux; \
          echo "Unsupported arch: ${ARCH}"; \
          exit 1; \
          ;; \
+    esac; \
+    . /etc/os-release; \
+    case "$ID" in \
+       centos*) \
+         yum-config-manager --disable epel && yum-config-manager --add-repo 'http://archives.fedoraproject.org/pub/archive/epel/7/$basearch'; \
+         ;; \
+       ubuntu*) \
+         apt install -y unzip; \
+         ;; \
     esac;
 ENV GOPATH=$HOME/go
 ENV PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
 RUN go install github.com/onsi/ginkgo/ginkgo@latest
 
+SHELL ["bash", "-c"]
 # Install gpdb source files
 WORKDIR /home/gpadmin/
 RUN mkdir -p /data1/master /data1/primary /data1/mirror && chmod -R 755 /data1 && \
@@ -49,6 +57,7 @@ RUN mkdir -p /data1/master /data1/primary /data1/mirror && chmod -R 755 /data1 &
     install_gpdb
 
 # Install PXF
+ENV JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
 ENV OUTPUT_ARTIFACT_DIR="pxf_tarball"
 COPY . /home/gpadmin/pxf_src
 COPY ./automation/arenadata/scripts/compile_pxf_without_test.sh ./pxf_src/concourse/scripts/compile_pxf_without_test.sh

--- a/automation/arenadata/build-images.sh
+++ b/automation/arenadata/build-images.sh
@@ -18,5 +18,5 @@ echo "=============================="
 echo "Build PXF image for automation"
 echo "=============================="
 pushd ../..
-docker build -t gpdb6_pxf_automation:it -f automation/arenadata/Dockerfile .
+docker build -t gpdb6_pxf_automation:it --build-arg "GPDB_IMAGE=${GPDB_IMAGE:-hub.adsw.io/library/gpdb6_regress:adb-6.x-dev}" -f automation/arenadata/Dockerfile .
 popd

--- a/automation/arenadata/build-images.sh
+++ b/automation/arenadata/build-images.sh
@@ -7,12 +7,13 @@ pushd ../../server
 ./gradlew clean
 popd
 
-echo "===================================="
-echo "      Build Hadoop 3.3.6 image      "
-echo "===================================="
-pushd hadoop
-docker build -f Dockerfile -t cloud-hub.adsw.io/library/pxf-hadoop:3.3.6 .
-popd
+# Uncomment this section if image is not available in the docker registry
+#echo "===================================="
+#echo "      Build Hadoop 3.3.6 image      "
+#echo "===================================="
+#pushd hadoop
+#docker build -f Dockerfile -t cloud-hub.adsw.io/library/pxf-hadoop:3.3.6 .
+#popd
 
 echo "=============================="
 echo "Build PXF image for automation"

--- a/concourse/scripts/pxf_common.bash
+++ b/concourse/scripts/pxf_common.bash
@@ -358,14 +358,16 @@ function setup_gpadmin_user() {
 		gpadmin soft nproc 131072
 		gpadmin soft nofile 65536
 	EOF
-	echo "export JAVA_HOME=${JAVA_HOME}" >> ~gpadmin/.bashrc
 	if [[ -d gpdb_src/gpAux/gpdemo ]]; then
 		chown -R gpadmin:gpadmin gpdb_src/gpAux/gpdemo
 	fi
 
 	if grep -i ubuntu /etc/os-release; then
+		echo "export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64" >> ~gpadmin/.bashrc
 		echo '[[ -f ~/.bashrc ]] && . ~/.bashrc' >> ~gpadmin/.bash_profile
 		chown gpadmin:gpadmin ~gpadmin/.bash_profile
+	else
+		echo "export JAVA_HOME=${JAVA_HOME}" >> ~gpadmin/.bashrc
 	fi
 }
 


### PR DESCRIPTION
Fix pxf tests on Ubuntu-based image

Adds support for Ubuntu-based image in dockerized tests. The following was
changed:

- Add branching to Dockerfile depending on the container OS (found in
  /etc/os-release)
- Replace hardcoded image in Dockerfile with GPDB_IMAGE argument. The hardcoded
  image is set as a default value in Dockerfile and build-images.sh
- Fix export JAVA_HOME for Ubuntu image in integration Dockerfile
- Install unzip for Ubuntu image in integration Dockerfile
- Allow UTF-8 in Java sources
- Fix command on several lines by using bash SHELL

Co-authored-by: Andrey Sokolov <a.sokolov@arenadata.io>

---
This PR should be merged via rebase as it contains commits from the Java-team.