### PR TITLE
ADBDEV-6351: Change error description if we don't support type

### DIFF
--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcResolver.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcResolver.java
@@ -274,8 +274,8 @@ public class JdbcResolver extends JdbcBasePlugin implements Resolver {
                         break;
                     default:
                         throw new UnsupportedOperationException(
-                                String.format("Field type '%s' (column '%s') is not supported",
-                                        oneFieldType, column));
+                                String.format("Column type '%s' (column '%s') is not supported",
+                                        columnType, column));
                 }
             }
         }


### PR DESCRIPTION
Instead of using `oneFieldType` which is always `TEXT` in our case we need to use `columnType` to show the type of the column we don't support.