### PR TITLE
ADBDEV-6475: Change command id source for PXF

### DIFF
--- a/external-table/src/pxfheaders.c
+++ b/external-table/src/pxfheaders.c
@@ -31,6 +31,7 @@
 #include "utils/timestamp.h"
 #include "nodes/makefuncs.h"
 #include "cdb/cdbvars.h"
+#include "storage/proc.h"
 
 /* helper function declarations */
 static void add_alignment_size_httpheader(CHURL_HEADERS headers);
@@ -183,7 +184,7 @@ build_http_headers(PxfInputData *input)
 
 	pg_ltoa(gp_session_id, long_number);
 	churl_headers_append(headers, "X-GP-SESSION-ID", long_number);
-	pg_ltoa(gp_command_count, long_number);
+	pg_ltoa(MyProc->queryCommandId, long_number);
 	churl_headers_append(headers, "X-GP-COMMAND-COUNT", long_number);
 
 	add_alignment_size_httpheader(headers);

--- a/fdw/pxf_header.c
+++ b/fdw/pxf_header.c
@@ -34,6 +34,7 @@
 #include "utils/formatting.h"
 #include "utils/timestamp.h"
 #include "utils/syscache.h"
+#include "storage/proc.h"
 
 /* helper function declarations */
 static void AddAlignmentSizeHttpHeader(CHURL_HEADERS headers);
@@ -108,7 +109,7 @@ BuildHttpHeaders(CHURL_HEADERS headers,
 
 	pg_ltoa(gp_session_id, long_number);
 	churl_headers_append(headers, "X-GP-SESSION-ID", long_number);
-	pg_ltoa(gp_command_count, long_number);
+	pg_ltoa(MyProc->queryCommandId, long_number);
 	churl_headers_append(headers, "X-GP-COMMAND-COUNT", long_number);
 
 	AddAlignmentSizeHttpHeader(headers);


### PR DESCRIPTION
Change command id source for PXF

Replace gp_command_count uses in PXF with PGPROC.queryCommandId.
This change is required due to change in GPDB core introduced by
7ee713d131ac3d1fa51fd1288790b9d0b5bae269 commit.

---

Note: gp_command_count is also mentioned in `pxffragment_test.c` unit test, however it seems to be dead code (since `pxffragment.c` itself is missing)