### PR TITLE
ADBDEV-6524: Change the reference to download Java 17 rpm package

### DIFF
--- a/arenadata/Dockerfile
+++ b/arenadata/Dockerfile
@@ -26,9 +26,9 @@ RUN set -eux; \
     case "$ID" in \
        centos*) \
          yum-config-manager --disable epel && yum-config-manager --add-repo 'http://archives.fedoraproject.org/pub/archive/epel/7/$basearch'; \
-         curl -fSL https://download.oracle.com/java/17/latest/jdk-17_linux-x64_bin.rpm -o /tmp/jdk-17_linux-x64_bin.rpm \
-             && yum -y install /tmp/jdk-17_linux-x64_bin.rpm \
-             && rm -rf /tmp/jdk-17_linux-x64_bin.rpm; \
+         curl -fSL https://download.oracle.com/java/17/archive/jdk-17.0.12_linux-x64_bin.rpm -o /tmp/jdk-17.0.12_linux-x64_bin.rpm \
+             && yum -y install /tmp/jdk-17.0.12_linux-x64_bin.rpm \
+             && rm -rf /tmp/jdk-17.0.12_linux-x64_bin.rpm; \
          sed -i "s/JAVA_HOME=.*/JAVA_HOME=\$(readlink -f \/usr\/bin\/java | sed 's:bin\/java::')/g" /etc/profile.d/jdk_home.sh; \
          ;; \
        ubuntu*) \

--- a/automation/arenadata/Dockerfile
+++ b/automation/arenadata/Dockerfile
@@ -39,9 +39,9 @@ RUN set -eux; \
     case "$ID" in \
        centos*) \
          yum-config-manager --disable epel && yum-config-manager --add-repo 'http://archives.fedoraproject.org/pub/archive/epel/7/$basearch'; \
-         curl -fSL https://download.oracle.com/java/17/latest/jdk-17_linux-x64_bin.rpm -o /tmp/jdk-17_linux-x64_bin.rpm && \
-           yum -y install /tmp/jdk-17_linux-x64_bin.rpm && \
-           rm -rf /tmp/jdk-17_linux-x64_bin.rpm; \
+         curl -fSL https://download.oracle.com/java/17/archive/jdk-17.0.12_linux-x64_bin.rpm -o /tmp/jdk-17.0.12_linux-x64_bin.rpm && \
+           yum -y install /tmp/jdk-17.0.12_linux-x64_bin.rpm && \
+           rm -rf /tmp/jdk-17.0.12_linux-x64_bin.rpm; \
          sed -i "s/JAVA_HOME=.*/JAVA_HOME=\$(readlink -f \/usr\/bin\/java | sed 's:bin\/java::')/g" /etc/profile.d/jdk_home.sh; \
          ;; \
        ubuntu*) \


### PR DESCRIPTION
Java 17 rpm package has been moved to the archive. To fix the problem we need to adjust the reference.